### PR TITLE
fix: Persistir PDFs de solicitudes con volumen Docker (closes #3)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,6 +46,8 @@ services:
       timeout: 5s
       retries: 3
       start_period: 30s
+    volumes:
+      - uploads_data:/app/uploads
     depends_on:
       postgres:
         condition: service_healthy
@@ -60,3 +62,4 @@ services:
 
 volumes:
   postgres_data:
+  uploads_data:


### PR DESCRIPTION
## Contexto

Resuelve el Issue #3 — los PDFs de solicitudes se perdían en cada `docker compose down` porque `/app/uploads` vivía dentro del filesystem efímero del contenedor `validacion-app`, no en un volumen persistente.

## Cambio

Agregadas 2 líneas en `docker-compose.yml`:

1. Sección `services.app.volumes`: monta `uploads_data` en `/app/uploads`.
2. Sección `volumes` (top-level): declara `uploads_data` como volumen nombrado gestionado por Docker.

Sin cambios en código, Dockerfile, o configuración Spring — `${UPLOAD_DIR:./uploads}` en `application.yml` ya resuelve al path correcto relativo al `WORKDIR /app`.

## Validación manual

- [x] `docker compose up --build -d` — volumen `ideaprojects_uploads_data` creado.
- [x] POST de nueva solicitud → PDF escrito a `/app/uploads/solicitudes-empresa/2026/04/{uuid}.pdf`.
- [x] `docker compose down` (sin `-v`) + `docker compose up -d` — PDF sigue físicamente en el volumen tras reinicio completo del contenedor.
- [x] GET por número de solicitud devuelve JSON íntegro post-reinicio.
- [x] BD y disco coherentes: `ruta_carta` en Postgres apunta al archivo real.

## Bugs laterales descubiertos (fuera de este PR)

Durante la validación se detectaron dos bugs no relacionados con el volumen, documentados en Issue #4:
- Generador de `numeroSolicitud` falla después de borrar registros (usa `COUNT` en vez de `MAX`).
- Mensaje del `GlobalExceptionHandler` engañoso al violarse UNIQUE constraint.

## Notas

- El volumen es nombrado (gestionado por Docker), no bind mount. Portable entre Windows/Linux/Mac.
- Para producción real conviene considerar storage externo (S3/MinIO), pero este fix es suficiente para entorno dev y deploy básico.
- Volumen persiste entre `docker compose down`. Se borra solo con `docker compose down -v` explícito.