### PR TITLE
fix: Generador robusto de numeroSolicitud + handler de conflictos específico (closes #4)

### DIFF
--- a/src/main/kotlin/co/edu/udemedellin/validacionacademica/application/usecase/GenerarNumeroSolicitudService.kt
+++ b/src/main/kotlin/co/edu/udemedellin/validacionacademica/application/usecase/GenerarNumeroSolicitudService.kt
@@ -11,14 +11,14 @@ import java.time.format.DateTimeFormatter
  * Genera el número de radicado único de una [co.edu.udemedellin.validacionacademica.domain.model.SolicitudEmpresa]
  * en el formato `SOL-YYYYMMDD-NNNNNN`, donde NNNNNN es el consecutivo diario con cero-relleno.
  *
- * El consecutivo se calcula contando los registros del día en la base de datos dentro de la
- * misma transacción que persiste la solicitud. La unicidad queda garantizada de forma definitiva
- * por la restricción UNIQUE de la columna `numero_solicitud` en la base de datos.
+ * El consecutivo se calcula a partir del MAX de `numero_solicitud` del día en la base de datos,
+ * parseando los últimos 6 dígitos y sumando 1. Esto lo hace inmune a gaps provocados por borrados:
+ * si existían [1, 2, 3] y se borró el 2, MAX=3 → siguiente=4 (sin colisión).
+ * El enfoque anterior basado en COUNT generaría 3 → colisión con el registro existente.
  *
- * Nota: ante una colisión por concurrencia extrema, la BD rechazará el segundo insert con
- * [org.springframework.dao.DataIntegrityViolationException]. Para el volumen de este sistema
- * (institución académica) esto es suficiente; si el volumen crece, migrar a una secuencia
- * dedicada por día (tabla `solicitud_consecutivo`).
+ * La unicidad queda garantizada de forma definitiva por la restricción UNIQUE de la columna
+ * `numero_solicitud`. Ante colisión por concurrencia extrema, la BD rechazará el segundo
+ * insert con [org.springframework.dao.DataIntegrityViolationException].
  */
 @Service
 class GenerarNumeroSolicitudService(
@@ -35,10 +35,14 @@ class GenerarNumeroSolicitudService(
      */
     @Transactional
     fun generar(fecha: LocalDate): String {
-        val count = solicitudEmpresaRepositoryPort.countByFecha(fecha)
-        val consecutivo = (count + 1).toString().padStart(6, '0')
-        val numero = "SOL-${fecha.format(dateFormatter)}-$consecutivo"
-        log.debug("Número de solicitud generado: {}", numero)
+        val maxNumero = solicitudEmpresaRepositoryPort.findMaxNumeroSolicitudByFecha(fecha)
+        val siguienteConsecutivo = if (maxNumero == null) {
+            1L
+        } else {
+            maxNumero.takeLast(6).toLong() + 1
+        }
+        val numero = "SOL-${fecha.format(dateFormatter)}-${siguienteConsecutivo.toString().padStart(6, '0')}"
+        log.debug("Número de solicitud generado: {} (basado en MAX={})", numero, maxNumero)
         return numero
     }
 }

--- a/src/main/kotlin/co/edu/udemedellin/validacionacademica/domain/ports/SolicitudEmpresaRepositoryPort.kt
+++ b/src/main/kotlin/co/edu/udemedellin/validacionacademica/domain/ports/SolicitudEmpresaRepositoryPort.kt
@@ -24,8 +24,10 @@ interface SolicitudEmpresaRepositoryPort {
     fun findByNumeroSolicitud(numero: String): SolicitudEmpresa?
 
     /**
-     * Cuenta cuántas solicitudes fueron creadas en la fecha calendario indicada.
-     * Usado por el generador de número de solicitud para calcular el consecutivo diario.
+     * Retorna el número de solicitud más alto (`SOL-YYYYMMDD-NNNNNN`) creado en la fecha
+     * calendario indicada, o `null` si no existe ningún registro para ese día.
+     * Usado por el generador de número de solicitud para calcular el consecutivo diario
+     * de forma segura ante borrados (MAX es inmune a gaps, COUNT no lo es).
      */
-    fun countByFecha(fecha: LocalDate): Long
+    fun findMaxNumeroSolicitudByFecha(fecha: LocalDate): String?
 }

--- a/src/main/kotlin/co/edu/udemedellin/validacionacademica/infrastructure/persistence/adapter/SolicitudEmpresaPersistenceAdapter.kt
+++ b/src/main/kotlin/co/edu/udemedellin/validacionacademica/infrastructure/persistence/adapter/SolicitudEmpresaPersistenceAdapter.kt
@@ -18,10 +18,10 @@ class SolicitudEmpresaPersistenceAdapter(
     override fun findByNumeroSolicitud(numero: String): SolicitudEmpresa? =
         jpaRepository.findByNumeroSolicitud(numero)?.toDomain()
 
-    override fun countByFecha(fecha: LocalDate): Long {
+    override fun findMaxNumeroSolicitudByFecha(fecha: LocalDate): String? {
         val startOfDay = fecha.atStartOfDay()
         val endOfDay = fecha.plusDays(1).atStartOfDay()
-        return jpaRepository.countByFecha(startOfDay, endOfDay)
+        return jpaRepository.findMaxNumeroSolicitudByFecha(startOfDay, endOfDay)
     }
 
     // ── Mapeos ────────────────────────────────────────────────────────────────

--- a/src/main/kotlin/co/edu/udemedellin/validacionacademica/infrastructure/persistence/repository/SolicitudEmpresaJpaRepository.kt
+++ b/src/main/kotlin/co/edu/udemedellin/validacionacademica/infrastructure/persistence/repository/SolicitudEmpresaJpaRepository.kt
@@ -11,18 +11,23 @@ interface SolicitudEmpresaJpaRepository : JpaRepository<SolicitudEmpresaEntity, 
     fun findByNumeroSolicitud(numeroSolicitud: String): SolicitudEmpresaEntity?
 
     /**
-     * Cuenta las solicitudes cuyo [SolicitudEmpresaEntity.createdAt] cae dentro del rango
-     * [startOfDay, endOfDay). Usado para calcular el consecutivo diario del número de solicitud.
+     * Retorna el número de solicitud (`SOL-YYYYMMDD-NNNNNN`) más alto cuyo
+     * [SolicitudEmpresaEntity.createdAt] cae dentro del rango [startOfDay, endOfDay),
+     * o `null` si no existe ningún registro en ese rango.
+     *
+     * El MAX léxico es correcto porque la fecha está fija dentro del rango y el sufijo
+     * numérico tiene cero-relleno a 6 dígitos, por lo que el orden léxico coincide
+     * con el orden numérico.
      *
      * Se usa un rango explícito (en lugar de DATE()) para garantizar compatibilidad
      * con H2 (dev) y PostgreSQL (producción) sin funciones específicas de cada BD.
      */
     @Query(
-        "SELECT COUNT(s) FROM SolicitudEmpresaEntity s " +
+        "SELECT MAX(s.numeroSolicitud) FROM SolicitudEmpresaEntity s " +
         "WHERE s.createdAt >= :startOfDay AND s.createdAt < :endOfDay"
     )
-    fun countByFecha(
+    fun findMaxNumeroSolicitudByFecha(
         @Param("startOfDay") startOfDay: LocalDateTime,
         @Param("endOfDay") endOfDay: LocalDateTime
-    ): Long
+    ): String?
 }

--- a/src/main/kotlin/co/edu/udemedellin/validacionacademica/infrastructure/rest/exception/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/co/edu/udemedellin/validacionacademica/infrastructure/rest/exception/GlobalExceptionHandler.kt
@@ -76,11 +76,22 @@ class GlobalExceptionHandler {
     }
 
     @ExceptionHandler(org.springframework.dao.DataIntegrityViolationException::class)
-    fun handleDuplicateKey(ex: Exception): ResponseEntity<ApiError> {
+    fun handleDuplicateKey(ex: org.springframework.dao.DataIntegrityViolationException): ResponseEntity<ApiError> {
+        val message = when (val cause = ex.cause) {
+            is org.hibernate.exception.ConstraintViolationException -> when (cause.constraintName) {
+                "idx_solicitud_numero" ->
+                    "No se pudo completar el registro por un conflicto interno. Por favor reintente la operación."
+                "idx_students_document" ->
+                    "Ya existe un estudiante con ese documento."
+                else ->
+                    "Conflicto de datos al guardar el registro."
+            }
+            else -> "Conflicto de datos al guardar el registro."
+        }
         val apiError = ApiError(
             status = HttpStatus.CONFLICT.value(),
             error = "Conflicto de datos",
-            message = "Ya existe un registro con ese documento"
+            message = message
         )
         return ResponseEntity.status(HttpStatus.CONFLICT).body(apiError)
     }

--- a/src/test/kotlin/co/edu/udemedellin/validacionacademica/infrastructure/rest/exception/GlobalExceptionHandlerTest.kt
+++ b/src/test/kotlin/co/edu/udemedellin/validacionacademica/infrastructure/rest/exception/GlobalExceptionHandlerTest.kt
@@ -1,0 +1,63 @@
+package co.edu.udemedellin.validacionacademica.infrastructure.rest.exception
+
+import org.hibernate.exception.ConstraintViolationException
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.springframework.dao.DataIntegrityViolationException
+import org.springframework.http.HttpStatus
+import java.sql.SQLException
+
+class GlobalExceptionHandlerTest {
+
+    private val handler = GlobalExceptionHandler()
+
+    @Test
+    fun `constraint idx_solicitud_numero responde con mensaje de conflicto interno`() {
+        val hibernateEx = ConstraintViolationException("duplicate key", SQLException("simulated"), "idx_solicitud_numero")
+        val ex = DataIntegrityViolationException("constraint violation", hibernateEx)
+
+        val response = handler.handleDuplicateKey(ex)
+
+        assertEquals(HttpStatus.CONFLICT, response.statusCode)
+        assertEquals(
+            "No se pudo completar el registro por un conflicto interno. Por favor reintente la operación.",
+            response.body?.message
+        )
+    }
+
+    @Test
+    fun `constraint idx_students_document responde con mensaje de documento duplicado`() {
+        val hibernateEx = ConstraintViolationException("duplicate key", SQLException("simulated"), "idx_students_document")
+        val ex = DataIntegrityViolationException("constraint violation", hibernateEx)
+
+        val response = handler.handleDuplicateKey(ex)
+
+        assertEquals(HttpStatus.CONFLICT, response.statusCode)
+        assertEquals("Ya existe un estudiante con ese documento.", response.body?.message)
+    }
+
+    @Test
+    fun `constraint desconocido responde con mensaje generico de conflicto`() {
+        val hibernateEx = ConstraintViolationException("duplicate key", SQLException("simulated"), "idx_otro_constraint_desconocido")
+        val ex = DataIntegrityViolationException("constraint violation", hibernateEx)
+
+        val response = handler.handleDuplicateKey(ex)
+
+        assertEquals(HttpStatus.CONFLICT, response.statusCode)
+        assertEquals("Conflicto de datos al guardar el registro.", response.body?.message)
+    }
+
+    @Test
+    fun `cause no es ConstraintViolationException responde con mensaje generico sin ClassCastException`() {
+        // Escenario: el driver o la configuración produce un cause distinto a
+        // org.hibernate.exception.ConstraintViolationException. El cast directo
+        // lanzaría ClassCastException → 500. El pattern matching seguro devuelve el fallback.
+        val cause = RuntimeException("unexpected cause from driver")
+        val ex = DataIntegrityViolationException("integrity violation", cause)
+
+        val response = handler.handleDuplicateKey(ex)
+
+        assertEquals(HttpStatus.CONFLICT, response.statusCode)
+        assertEquals("Conflicto de datos al guardar el registro.", response.body?.message)
+    }
+}

--- a/src/test/kotlin/co/edu/udemedellin/validacionacademica/usecase/GenerarNumeroSolicitudServiceTest.kt
+++ b/src/test/kotlin/co/edu/udemedellin/validacionacademica/usecase/GenerarNumeroSolicitudServiceTest.kt
@@ -1,0 +1,51 @@
+package co.edu.udemedellin.validacionacademica.usecase
+
+import co.edu.udemedellin.validacionacademica.application.usecase.GenerarNumeroSolicitudService
+import co.edu.udemedellin.validacionacademica.domain.ports.SolicitudEmpresaRepositoryPort
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+
+class GenerarNumeroSolicitudServiceTest {
+
+    private val solicitudRepo: SolicitudEmpresaRepositoryPort = mockk()
+    private val service = GenerarNumeroSolicitudService(solicitudRepo)
+
+    private val fecha = LocalDate.of(2026, 4, 22)
+
+    @Test
+    fun `cuando no hay registros del dia, genera 000001`() {
+        every { solicitudRepo.findMaxNumeroSolicitudByFecha(fecha) } returns null
+
+        val resultado = service.generar(fecha)
+
+        assertEquals("SOL-20260422-000001", resultado)
+        verify(exactly = 1) { solicitudRepo.findMaxNumeroSolicitudByFecha(fecha) }
+    }
+
+    @Test
+    fun `cuando hay registros del dia, usa el maximo mas uno`() {
+        every { solicitudRepo.findMaxNumeroSolicitudByFecha(fecha) } returns "SOL-20260422-000003"
+
+        val resultado = service.generar(fecha)
+
+        assertEquals("SOL-20260422-000004", resultado)
+        verify(exactly = 1) { solicitudRepo.findMaxNumeroSolicitudByFecha(fecha) }
+    }
+
+    @Test
+    fun `cuando se borro una solicitud intermedia, no colisiona con registros existentes`() {
+        // Escenario: existían SOL-20260422-000001, SOL-20260422-000002, SOL-20260422-000003
+        // Se borró SOL-20260422-000002. MAX del día = 000003.
+        // Enfoque anterior (COUNT): count=2 → siguiente=000003 → COLISIÓN con el registro existente.
+        // Enfoque corregido  (MAX):  max=000003 → siguiente=000004 → SIN COLISIÓN.
+        every { solicitudRepo.findMaxNumeroSolicitudByFecha(fecha) } returns "SOL-20260422-000003"
+
+        val resultado = service.generar(fecha)
+
+        assertEquals("SOL-20260422-000004", resultado)
+    }
+}


### PR DESCRIPTION
## Contexto

Resuelve el Issue #4 — dos bugs descubiertos durante la validación del PR #5.

## Bug 1: Generador de numeroSolicitud usaba COUNT

El servicio `GenerarNumeroSolicitudService` calculaba el siguiente número con `count + 1`. Tras borrar una solicitud, el contador se desincronizaba y el siguiente número generado chocaba con un registro existente.

**Reproducción anterior:**
1. Crear [SOL-...-000001, SOL-...-000002, SOL-...-000003].
2. Borrar SOL-...-000002.
3. Crear nueva → intenta SOL-...-000003 (COUNT=2, +1=3) → colisión UNIQUE.

**Fix:** usar `MAX(numero_solicitud)` del día y parsear los últimos 6 dígitos. Inmune a gaps por borrado.

## Bug 2: GlobalExceptionHandler con mensaje engañoso

Cualquier violación de UNIQUE constraint respondía "Ya existe un registro con ese documento", aunque el conflicto real fuera en `numero_solicitud` u otra columna. Esto confundió gravemente el debug del Bug 1 (buscábamos un problema de documento cuando era de número).

**Fix:** mapeo por nombre de constraint:
- `idx_solicitud_numero` → "No se pudo completar el registro por un conflicto interno. Por favor reintente la operación."
- `idx_students_document` → "Ya existe un estudiante con ese documento."
- Cualquier otro → "Conflicto de datos al guardar el registro."
- Con pattern matching seguro: si el `cause` no es `ConstraintViolationException` de Hibernate, cae al default sin lanzar ClassCastException.

## Cambios

**Código (5 archivos):**
- `SolicitudEmpresaRepositoryPort.kt`: `countByFecha` → `findMaxNumeroSolicitudByFecha`.
- `SolicitudEmpresaJpaRepository.kt`: query JPQL `COUNT` → `MAX`.
- `SolicitudEmpresaPersistenceAdapter.kt`: implementación actualizada.
- `GenerarNumeroSolicitudService.kt`: lógica nueva con parsing.
- `GlobalExceptionHandler.kt`: `when` sobre `cause` y `constraintName`.

**Tests (2 archivos nuevos, 7 tests):**
- `GenerarNumeroSolicitudServiceTest.kt`: 3 tests (sin registros, con registros, escenario crear-borrar-crear demostrando la inmunidad a gaps).
- `GlobalExceptionHandlerTest.kt`: 4 tests (los 3 constraints mapeados + cause no-Hibernate sin ClassCastException).

## Validación

- [x] `./gradlew test --rerun-tasks` → BUILD SUCCESSFUL, 36s, todos los tests verdes.
- [x] Suite completa incluye los 67 tests previos + 7 nuevos = 74.
- [x] Sin warnings nuevos introducidos.

## Notas de diseño

- `MAX` léxico es correcto porque el prefijo `SOL-YYYYMMDD-` es fijo dentro del rango diario y el sufijo está cero-rellenado a 6 dígitos, por lo que el orden léxico coincide con el numérico.
- El constraint de unicidad a nivel BD sigue siendo la última línea de defensa ante condiciones de carrera extremas.