### PR TITLE
feat: Migrar gestión de schema a Flyway en perfil Postgres (closes #2)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -58,6 +58,10 @@ dependencies {
     runtimeOnly("org.postgresql:postgresql")
     runtimeOnly("com.h2database:h2")
 
+    // --- MIGRACIONES DE SCHEMA ---
+    implementation("org.flywaydb:flyway-core")
+    implementation("org.flywaydb:flyway-database-postgresql")
+
     // --- PRUEBAS ---
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.springframework.security:spring-security-test")

--- a/src/main/resources/application-postgres.yml
+++ b/src/main/resources/application-postgres.yml
@@ -6,12 +6,15 @@ spring:
     driver-class-name: org.postgresql.Driver
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: validate
     show-sql: false
-    defer-datasource-initialization: true
+    defer-datasource-initialization: false  # Flyway gestiona el schema; no aplica el init de Spring Boot
     properties:
       hibernate:
         format_sql: true
+  flyway:
+    enabled: true
+    locations: classpath:db/migration
   sql:
     init:
       mode: never

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -65,6 +65,9 @@ spring:
             enable: ${MAIL_SSL_ENABLE:true}
             trust: smtp.gmail.com
 
+  flyway:
+    enabled: false  # Flyway solo activo en perfil postgres; en H2 usa create-drop + data.sql
+
   sql:
     init:
       mode: always

--- a/src/main/resources/db/migration/V1__initial_schema.sql
+++ b/src/main/resources/db/migration/V1__initial_schema.sql
@@ -1,0 +1,109 @@
+-- =============================================================
+-- V1: Schema inicial — validacion-academica-ms
+-- Cubre las 5 entidades JPA activas al momento de introducir
+-- Flyway. Los tipos y longitudes reflejan exactamente lo que
+-- Hibernate genera con SpringPhysicalNamingStrategy para que
+-- ddl-auto: validate no falle al arrancar.
+-- =============================================================
+
+-- -------------------------------------------------------------
+-- 1. students
+-- -------------------------------------------------------------
+CREATE TABLE students (
+    id            BIGSERIAL     PRIMARY KEY,
+    document      VARCHAR(20)   NOT NULL,
+    full_name     VARCHAR(150)  NOT NULL,
+    program       VARCHAR(200)  NOT NULL,
+    academic_level VARCHAR(20)  NOT NULL,
+    status        VARCHAR(20)   NOT NULL,
+    degree_title  VARCHAR(200),
+    graduation_date DATE
+);
+
+CREATE UNIQUE INDEX idx_students_document ON students (document);
+CREATE        INDEX idx_students_status   ON students (status);
+
+-- -------------------------------------------------------------
+-- 2. validation_requests
+-- -------------------------------------------------------------
+CREATE TABLE validation_requests (
+    id                BIGSERIAL    PRIMARY KEY,
+    requester_name    VARCHAR(150) NOT NULL,
+    requester_email   VARCHAR(254) NOT NULL,
+    student_document  VARCHAR(20)  NOT NULL,
+    validation_type   VARCHAR(20)  NOT NULL,
+    created_at        TIMESTAMP    NOT NULL,
+    verification_code VARCHAR(20)  NOT NULL
+);
+
+CREATE        INDEX idx_validation_student_document   ON validation_requests (student_document);
+CREATE UNIQUE INDEX idx_validation_verification_code  ON validation_requests (verification_code);
+
+-- -------------------------------------------------------------
+-- 3. email_verification_codes
+--    FK: validation_request_id → validation_requests(id)
+-- -------------------------------------------------------------
+CREATE TABLE email_verification_codes (
+    id                    BIGSERIAL    PRIMARY KEY,
+    token                 VARCHAR(36)  NOT NULL,
+    email                 VARCHAR(254) NOT NULL,
+    code                  VARCHAR(6)   NOT NULL,
+    validation_request_id BIGINT       NOT NULL
+        REFERENCES validation_requests (id) ON DELETE NO ACTION,
+    student_document      VARCHAR(20)  NOT NULL,
+    -- SMELL: falta length=20 en @Column de EmailVerificationEntity.validationType.
+    -- Hibernate defaultea VARCHAR(255) cuando no se especifica length en @Enumerated(STRING).
+    -- Deuda menor: normalizar a VARCHAR(20) en migración futura junto con el ajuste en la entidad.
+    validation_type       VARCHAR(255) NOT NULL,
+    requester_name        VARCHAR(150) NOT NULL,
+    expires_at            TIMESTAMP    NOT NULL,
+    created_at            TIMESTAMP    NOT NULL,
+    used                  BOOLEAN      NOT NULL
+);
+
+CREATE UNIQUE INDEX idx_email_verification_token ON email_verification_codes (token);
+
+-- -------------------------------------------------------------
+-- 4. audit_events
+-- -------------------------------------------------------------
+CREATE TABLE audit_events (
+    id               BIGSERIAL    PRIMARY KEY,
+    action           VARCHAR(30)  NOT NULL,
+    performed_by     VARCHAR(100) NOT NULL,
+    target_document  VARCHAR(20),
+    details          VARCHAR(500),
+    timestamp        TIMESTAMP    NOT NULL
+);
+
+CREATE INDEX idx_audit_performed_by ON audit_events (performed_by);
+CREATE INDEX idx_audit_timestamp    ON audit_events (timestamp);
+CREATE INDEX idx_audit_action       ON audit_events (action);
+
+-- -------------------------------------------------------------
+-- 5. solicitudes_empresa
+-- -------------------------------------------------------------
+CREATE TABLE solicitudes_empresa (
+    id                        BIGSERIAL    PRIMARY KEY,
+    numero_solicitud          VARCHAR(25)  NOT NULL,
+    nombre_empresa            VARCHAR(200) NOT NULL,
+    nit_empresa               VARCHAR(20)  NOT NULL,
+    nombre_contacto           VARCHAR(150) NOT NULL,
+    cargo_contacto            VARCHAR(100) NOT NULL,
+    correo_contacto           VARCHAR(254) NOT NULL,
+    telefono_contacto         VARCHAR(20),
+    tipo_documento_estudiante VARCHAR(10)  NOT NULL,
+    documento_estudiante      VARCHAR(20)  NOT NULL,
+    nombre_estudiante         VARCHAR(150) NOT NULL,
+    programa_consultado       VARCHAR(200),
+    tipo_validacion           VARCHAR(20)  NOT NULL,
+    observaciones             VARCHAR(500),
+    acepta_terminos           BOOLEAN      NOT NULL,
+    ruta_carta                VARCHAR(500) NOT NULL,
+    estado                    VARCHAR(20)  NOT NULL,
+    created_at                TIMESTAMP    NOT NULL,
+    updated_at                TIMESTAMP
+);
+
+CREATE UNIQUE INDEX idx_solicitud_numero               ON solicitudes_empresa (numero_solicitud);
+CREATE        INDEX idx_solicitud_created_at           ON solicitudes_empresa (created_at);
+CREATE        INDEX idx_solicitud_documento_estudiante ON solicitudes_empresa (documento_estudiante);

--- a/src/main/resources/db/migration/V2__seed_data.sql
+++ b/src/main/resources/db/migration/V2__seed_data.sql
@@ -1,0 +1,26 @@
+-- =============================================================
+-- V2: Seed data inicial — estudiantes de demostración
+-- Equivalente al data.sql usado por el perfil H2 (create-drop).
+-- ON CONFLICT DO NOTHING protege ante re-ejecuciones accidentales
+-- en entornos con flyway.outOfOrder o restauraciones parciales.
+-- =============================================================
+
+INSERT INTO students (document, full_name, program, academic_level, status, degree_title, graduation_date)
+VALUES ('10350001', 'Ana Gomez', 'Medicina', 'PREGRADO', 'ACTIVO', NULL, NULL)
+ON CONFLICT (document) DO NOTHING;
+
+INSERT INTO students (document, full_name, program, academic_level, status, degree_title, graduation_date)
+VALUES ('10350002', 'Carlos Perez', 'Ingenieria de Sistemas', 'PREGRADO', 'ACTIVO', NULL, NULL)
+ON CONFLICT (document) DO NOTHING;
+
+INSERT INTO students (document, full_name, program, academic_level, status, degree_title, graduation_date)
+VALUES ('10350003', 'Maria Torres', 'Derecho', 'ESPECIALIZACION', 'GRADUADO', 'Abogada', '2024-06-15')
+ON CONFLICT (document) DO NOTHING;
+
+INSERT INTO students (document, full_name, program, academic_level, status, degree_title, graduation_date)
+VALUES ('10350004', 'Jorge Ramirez', 'Administracion de Empresas', 'PREGRADO', 'ACTIVO', NULL, NULL)
+ON CONFLICT (document) DO NOTHING;
+
+INSERT INTO students (document, full_name, program, academic_level, status, degree_title, graduation_date)
+VALUES ('10350005', 'Sofia Herrera', 'Psicologia', 'MAESTRIA', 'GRADUADO', 'Psicologa Clinica', '2025-11-30')
+ON CONFLICT (document) DO NOTHING;


### PR DESCRIPTION
## Contexto

Resuelve el Issue #2 — el esquema de BD estaba gestionado por Hibernate con `ddl-auto: update` en Postgres, lo que impedía auditoría de cambios, rollback y control de versiones del schema.

## Cambios

**Dependencias (`build.gradle.kts`):**
- `org.flywaydb:flyway-core`
- `org.flywaydb:flyway-database-postgresql` (obligatorio en Flyway 10+, los módulos por BD se separaron).

**Configuración:**
- `application.yml`: `spring.flyway.enabled: false` explícito para perfil default (H2 sigue con `create-drop` + `data.sql`).
- `application-postgres.yml`: `ddl-auto: update` → `validate`, Flyway habilitado, `defer-datasource-initialization: false` (sobrescribe el `true` heredado del base, era la causa de un `Circular depends-on` entre Flyway y JPA).

**Migraciones nuevas:**
- `V1__initial_schema.sql`: crea las 5 tablas actuales (`students`, `validation_requests`, `email_verification_codes`, `audit_events`, `solicitudes_empresa`) con todos sus índices y constraints. Incluye FK formal `email_verification_codes.validation_request_id → validation_requests.id`.
- `V2__seed_data.sql`: 5 estudiantes seed con `ON CONFLICT (document) DO NOTHING` como protección ante re-ejecuciones.

## Estrategia

- **Perfil default (H2):** Flyway desactivado. `ddl-auto: create-drop` + `data.sql` siguen funcionando como antes. Dev rápido sin Flyway.
- **Perfil postgres:** Flyway gestiona schema y seed. `ddl-auto: validate` garantiza que las entidades JPA correspondan exactamente con lo que Flyway crea.
- **Baseline desde cero:** se destruyó el volumen de Postgres antes del primer arranque para empezar limpio. No usa `baselineOnMigrate`.

## Validación

- [x] `./gradlew test --rerun-tasks` → BUILD SUCCESSFUL, sin logs de Flyway en H2.
- [x] `docker compose up --build -d` → backend arranca, Flyway aplica V1 y V2.
- [x] `flyway_schema_history` registra ambas migraciones con `success = t`.
- [x] 5 estudiantes seed presentes en `students`.
- [x] Las 5 tablas de dominio existen según `\dt`.
- [x] Endpoint `GET /api/v1/solicitudes-empresa/{formato-inválido}` responde 400 con mensaje limpio (Bean Validation funciona, no hay regresiones en el handler).

## Deuda menor documentada

`email_verification_codes.validation_type` está como `VARCHAR(255)` en V1 porque `EmailVerificationEntity` no declara `length=20` en `@Enumerated(STRING)`. Es un smell heredado. Normalizarlo requerirá una futura migración `V3__` más el ajuste en la entidad JPA. No bloquea este PR.

## Impacto

- En dev con H2: ningún cambio visible, todo sigue como antes.
- En Postgres: ahora cualquier cambio de schema requiere una migración versionada. Disciplina ganada.
- Para desplegar: la primera vez que arranque en un Postgres vacío, Flyway crea todo. En un Postgres que ya tenía tablas creadas por Hibernate, habría que hacer `baseline` manualmente — fuera del scope de este PR.