### PR TITLE
feat: Endpoint público de consulta de estado de solicitud empresa

### DIFF
--- a/src/main/kotlin/co/edu/udemedellin/validacionacademica/application/usecase/ConsultarEstadoPublicoSolicitudUseCase.kt
+++ b/src/main/kotlin/co/edu/udemedellin/validacionacademica/application/usecase/ConsultarEstadoPublicoSolicitudUseCase.kt
@@ -1,0 +1,30 @@
+package co.edu.udemedellin.validacionacademica.application.usecase
+
+import co.edu.udemedellin.validacionacademica.domain.model.SolicitudEmpresa
+import co.edu.udemedellin.validacionacademica.domain.ports.SolicitudEmpresaRepositoryPort
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+/**
+ * Caso de uso: consulta pública del estado de una solicitud de empresa por número de radicado.
+ *
+ * Devuelve el modelo de dominio completo. La decisión de qué campos exponer
+ * públicamente es responsabilidad del DTO ([ConsultaPublicaSolicitudResponse])
+ * y su función de extensión [toPublicResponse].
+ */
+@Service
+class ConsultarEstadoPublicoSolicitudUseCase(
+    private val solicitudEmpresaRepositoryPort: SolicitudEmpresaRepositoryPort
+) {
+    private val log = LoggerFactory.getLogger(ConsultarEstadoPublicoSolicitudUseCase::class.java)
+
+    /**
+     * @return la solicitud encontrada, o `null` si no existe ninguna con ese número.
+     */
+    @Transactional(readOnly = true)
+    fun execute(numeroSolicitud: String): SolicitudEmpresa? {
+        log.debug("Consulta pública de estado: {}", numeroSolicitud)
+        return solicitudEmpresaRepositoryPort.findByNumeroSolicitud(numeroSolicitud)
+    }
+}

--- a/src/main/kotlin/co/edu/udemedellin/validacionacademica/infrastructure/config/SecurityConfig.kt
+++ b/src/main/kotlin/co/edu/udemedellin/validacionacademica/infrastructure/config/SecurityConfig.kt
@@ -155,7 +155,8 @@ open class SecurityConfig(
                     "/actuator/health",
                     "/actuator/info",
                     "/",
-                    "/verificar"
+                    "/verificar",
+                    "/api/v1/public/**"
                 ).permitAll()
 
                 // Métricas Prometheus — requiere JWT de ADMIN

--- a/src/main/kotlin/co/edu/udemedellin/validacionacademica/infrastructure/rest/controller/ConsultaPublicaSolicitudController.kt
+++ b/src/main/kotlin/co/edu/udemedellin/validacionacademica/infrastructure/rest/controller/ConsultaPublicaSolicitudController.kt
@@ -1,0 +1,75 @@
+package co.edu.udemedellin.validacionacademica.infrastructure.rest.controller
+
+import co.edu.udemedellin.validacionacademica.application.usecase.ConsultarEstadoPublicoSolicitudUseCase
+import co.edu.udemedellin.validacionacademica.infrastructure.rest.dto.ConsultaPublicaSolicitudResponse
+import co.edu.udemedellin.validacionacademica.infrastructure.rest.dto.toPublicResponse
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.constraints.Pattern
+import org.slf4j.LoggerFactory
+import org.springframework.http.ResponseEntity
+import org.springframework.validation.annotation.Validated
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+/**
+ * Endpoint público para consulta de estado de solicitudes de empresa.
+ *
+ * Solo expone un subconjunto reducido de campos a través de
+ * [ConsultaPublicaSolicitudResponse]. No requiere autenticación.
+ */
+@RestController
+@RequestMapping("/api/v1/public/solicitudes-empresa")
+@Tag(name = "Consulta Pública — Solicitudes Empresa", description = "Estado público de una solicitud de verificación académica por empresa")
+@Validated
+class ConsultaPublicaSolicitudController(
+    private val consultarEstadoPublicoSolicitudUseCase: ConsultarEstadoPublicoSolicitudUseCase
+) {
+    private val log = LoggerFactory.getLogger(ConsultaPublicaSolicitudController::class.java)
+
+    @GetMapping("/{numero}/estado")
+    @Operation(
+        summary = "Consultar estado público de solicitud",
+        description = """Retorna el estado actual de una solicitud de verificación académica por empresa.
+
+Solo expone los campos necesarios para que el solicitante identifique su radicado:
+número, estado, fechas, nombre de empresa y estudiante.
+El motivo de rechazo se incluye únicamente cuando el estado es `RECHAZADA`.
+
+No requiere autenticación. Sujeto a rate limiting."""
+    )
+    @ApiResponses(
+        ApiResponse(responseCode = "200", description = "Solicitud encontrada"),
+        ApiResponse(
+            responseCode = "400",
+            description = "Formato de número de solicitud inválido (debe ser SOL-YYYYMMDD-NNNNNN)",
+            content = [Content(schema = Schema(hidden = true))]
+        ),
+        ApiResponse(
+            responseCode = "404",
+            description = "No existe solicitud con ese número de radicado",
+            content = [Content(schema = Schema(hidden = true))]
+        )
+    )
+    fun consultarEstado(
+        @Parameter(description = "Número de radicado", example = "SOL-20260422-000001")
+        @PathVariable
+        @Pattern(
+            regexp = "^SOL-\\d{8}-\\d{6}$",
+            message = "El número de solicitud debe tener el formato SOL-YYYYMMDD-NNNNNN"
+        )
+        numero: String
+    ): ResponseEntity<ConsultaPublicaSolicitudResponse> {
+        log.debug("Consulta pública: {}", numero)
+        val solicitud = consultarEstadoPublicoSolicitudUseCase.execute(numero)
+            ?: return ResponseEntity.notFound().build()
+        return ResponseEntity.ok(solicitud.toPublicResponse())
+    }
+}

--- a/src/main/kotlin/co/edu/udemedellin/validacionacademica/infrastructure/rest/dto/ConsultaPublicaSolicitudResponse.kt
+++ b/src/main/kotlin/co/edu/udemedellin/validacionacademica/infrastructure/rest/dto/ConsultaPublicaSolicitudResponse.kt
@@ -1,0 +1,43 @@
+package co.edu.udemedellin.validacionacademica.infrastructure.rest.dto
+
+import co.edu.udemedellin.validacionacademica.domain.model.EstadoSolicitud
+import co.edu.udemedellin.validacionacademica.domain.model.SolicitudEmpresa
+import java.time.LocalDateTime
+
+/**
+ * DTO reducido para la consulta pública de estado de una solicitud de empresa.
+ *
+ * Expone únicamente los campos necesarios para que el solicitante confirme
+ * su radicado y conozca el estado actual. Campos sensibles (NIT, contacto,
+ * documento del estudiante, adminResponsable, etc.) quedan excluidos.
+ *
+ * [motivoRechazo] solo está presente cuando [estado] == RECHAZADA;
+ * en cualquier otro estado su valor es null.
+ */
+data class ConsultaPublicaSolicitudResponse(
+    val numeroSolicitud: String,
+    val estado: EstadoSolicitud,
+    val createdAt: LocalDateTime,
+    val fechaRevision: LocalDateTime?,
+    val nombreEmpresa: String,
+    val nombreEstudiante: String,
+    val motivoRechazo: String?
+)
+
+/**
+ * Mapea un modelo de dominio al DTO público.
+ *
+ * Lógica de privacidad:
+ * - [motivoRechazo] expone [SolicitudEmpresa.comentarioAdmin] SOLO cuando el estado es RECHAZADA.
+ * - [SolicitudEmpresa.adminResponsable] se omite siempre (identidad del funcionario).
+ * - Todos los demás campos sensibles (NIT, contacto, documento, etc.) se omiten siempre.
+ */
+fun SolicitudEmpresa.toPublicResponse() = ConsultaPublicaSolicitudResponse(
+    numeroSolicitud = numeroSolicitud,
+    estado = estado,
+    createdAt = createdAt,
+    fechaRevision = fechaRevision,
+    nombreEmpresa = nombreEmpresa,
+    nombreEstudiante = nombreEstudiante,
+    motivoRechazo = if (estado == EstadoSolicitud.RECHAZADA) comentarioAdmin else null
+)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -103,6 +103,9 @@ app:
       - prefix: /api/v1/solicitudes-empresa
         capacity: 10
         refill-minutes: 1
+      - prefix: /api/v1/public/solicitudes-empresa
+        capacity: 20
+        refill-minutes: 1
   security:
     jwt:
       secret: ${JWT_SECRET:changeme-replace-in-production-min32chars!}

--- a/src/test/kotlin/co/edu/udemedellin/validacionacademica/controller/ConsultaPublicaSolicitudControllerIntegrationTest.kt
+++ b/src/test/kotlin/co/edu/udemedellin/validacionacademica/controller/ConsultaPublicaSolicitudControllerIntegrationTest.kt
@@ -1,0 +1,164 @@
+package co.edu.udemedellin.validacionacademica.controller
+
+import co.edu.udemedellin.validacionacademica.bootstrap.ValidacionAcademicaApplication
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.http.MediaType
+import org.springframework.mock.web.MockMultipartFile
+import org.springframework.mock.web.MockPart
+import org.springframework.security.test.context.support.WithMockUser
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.TestPropertySource
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.transaction.annotation.Transactional
+
+@SpringBootTest(classes = [ValidacionAcademicaApplication::class])
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Transactional
+@TestPropertySource(properties = ["app.storage.upload-dir=./target/test-uploads"])
+class ConsultaPublicaSolicitudControllerIntegrationTest {
+
+    @Autowired
+    lateinit var mockMvc: MockMvc
+
+    @Autowired
+    lateinit var objectMapper: ObjectMapper
+
+    // ── Helper para crear solicitud y obtener su número ───────────────────────
+
+    private fun crearSolicitudYObtenerNumero(): String {
+        val datos = mapOf(
+            "nombreEmpresa"           to "Empresa Test S.A.S.",
+            "nitEmpresa"              to "890123456-1",
+            "nombreContacto"          to "Juan Pérez",
+            "cargoContacto"           to "Gerente RRHH",
+            "correoContacto"          to "rrhh@empresa.com",
+            "tipoDocumentoEstudiante" to "CC",
+            "documentoEstudiante"     to "10350001",
+            "nombreEstudiante"        to "Ana Gomez",
+            "tipoValidacion"          to "DEGREE",
+            "aceptaTerminos"          to true
+        )
+        val datosPart = MockPart("datos", objectMapper.writeValueAsString(datos).toByteArray()).also {
+            it.headers.contentType = MediaType.APPLICATION_JSON
+        }
+        val carta = MockMultipartFile("carta", "carta.pdf", "application/pdf", "contenido-pdf".toByteArray())
+
+        val result = mockMvc.perform(
+            multipart("/api/v1/solicitudes-empresa").part(datosPart).file(carta)
+        ).andExpect(status().isCreated).andReturn()
+
+        return objectMapper.readTree(result.response.contentAsString)["numeroSolicitud"].asText()
+    }
+
+    // ── Happy path ────────────────────────────────────────────────────────────
+
+    @Test
+    fun `GET estado devuelve 200 con campos publicos para solicitud PENDIENTE`() {
+        val numero = crearSolicitudYObtenerNumero()
+
+        mockMvc.perform(get("/api/v1/public/solicitudes-empresa/$numero/estado"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.numeroSolicitud").value(numero))
+            .andExpect(jsonPath("$.estado").value("PENDIENTE"))
+            .andExpect(jsonPath("$.nombreEmpresa").value("Empresa Test S.A.S."))
+            .andExpect(jsonPath("$.nombreEstudiante").value("Ana Gomez"))
+            .andExpect(jsonPath("$.motivoRechazo").doesNotExist())
+            .andExpect(jsonPath("$.fechaRevision").doesNotExist())
+    }
+
+    @Test
+    fun `GET estado no expone campos sensibles en respuesta`() {
+        val numero = crearSolicitudYObtenerNumero()
+
+        mockMvc.perform(get("/api/v1/public/solicitudes-empresa/$numero/estado"))
+            .andExpect(status().isOk)
+            // Campos que NO deben aparecer
+            .andExpect(jsonPath("$.nitEmpresa").doesNotExist())
+            .andExpect(jsonPath("$.correoContacto").doesNotExist())
+            .andExpect(jsonPath("$.nombreContacto").doesNotExist())
+            .andExpect(jsonPath("$.documentoEstudiante").doesNotExist())
+            .andExpect(jsonPath("$.adminResponsable").doesNotExist())
+            .andExpect(jsonPath("$.comentarioAdmin").doesNotExist())
+            .andExpect(jsonPath("$.rutaCarta").doesNotExist())
+            .andExpect(jsonPath("$.aceptaTerminos").doesNotExist())
+            .andExpect(jsonPath("$.tipoValidacion").doesNotExist())
+    }
+
+    @Test
+    @WithMockUser(username = "admin", roles = ["ADMIN"])
+    fun `GET estado en RECHAZADA expone motivoRechazo`() {
+        val numero = crearSolicitudYObtenerNumero()
+
+        mockMvc.perform(
+            post("/api/v1/admin/solicitudes-empresa/$numero/rechazar")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""{"comentarioAdmin":"Carta ilegible"}""")
+        ).andExpect(status().isOk)
+
+        mockMvc.perform(get("/api/v1/public/solicitudes-empresa/$numero/estado"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.estado").value("RECHAZADA"))
+            .andExpect(jsonPath("$.motivoRechazo").value("Carta ilegible"))
+            .andExpect(jsonPath("$.adminResponsable").doesNotExist())
+    }
+
+    @Test
+    @WithMockUser(username = "admin", roles = ["ADMIN"])
+    fun `GET estado en APROBADA no expone motivoRechazo`() {
+        val numero = crearSolicitudYObtenerNumero()
+
+        mockMvc.perform(
+            post("/api/v1/admin/solicitudes-empresa/$numero/aprobar")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""{"comentarioAdmin":"Todo correcto"}""")
+        ).andExpect(status().isOk)
+
+        mockMvc.perform(get("/api/v1/public/solicitudes-empresa/$numero/estado"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.estado").value("APROBADA"))
+            .andExpect(jsonPath("$.motivoRechazo").doesNotExist())
+    }
+
+    // ── 404 ───────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `GET estado devuelve 404 para numero inexistente`() {
+        mockMvc.perform(get("/api/v1/public/solicitudes-empresa/SOL-19990101-000001/estado"))
+            .andExpect(status().isNotFound)
+    }
+
+    // ── 400 — formato inválido ────────────────────────────────────────────────
+
+    @Test
+    fun `GET estado devuelve 400 para numero con formato invalido`() {
+        mockMvc.perform(get("/api/v1/public/solicitudes-empresa/numero-malo/estado"))
+            .andExpect(status().isBadRequest)
+    }
+
+    @Test
+    fun `GET estado devuelve 400 para numero sin guiones`() {
+        mockMvc.perform(get("/api/v1/public/solicitudes-empresa/SOL20260423000001/estado"))
+            .andExpect(status().isBadRequest)
+    }
+
+    // ── Sin autenticación (debe funcionar sin JWT) ────────────────────────────
+
+    @Test
+    fun `GET estado es accesible sin autenticacion`() {
+        val numero = crearSolicitudYObtenerNumero()
+
+        // No hay @WithMockUser — request totalmente anónimo
+        mockMvc.perform(get("/api/v1/public/solicitudes-empresa/$numero/estado"))
+            .andExpect(status().isOk)
+    }
+}

--- a/src/test/kotlin/co/edu/udemedellin/validacionacademica/usecase/ConsultarEstadoPublicoSolicitudUseCaseTest.kt
+++ b/src/test/kotlin/co/edu/udemedellin/validacionacademica/usecase/ConsultarEstadoPublicoSolicitudUseCaseTest.kt
@@ -1,0 +1,113 @@
+git commit -m "feat: endpoint publico de consulta de estado de solicitud empresa"package co.edu.udemedellin.validacionacademica.usecase
+
+import co.edu.udemedellin.validacionacademica.application.usecase.ConsultarEstadoPublicoSolicitudUseCase
+import co.edu.udemedellin.validacionacademica.domain.model.*
+import co.edu.udemedellin.validacionacademica.domain.ports.SolicitudEmpresaRepositoryPort
+import co.edu.udemedellin.validacionacademica.infrastructure.rest.dto.toPublicResponse
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import java.time.LocalDateTime
+
+class ConsultarEstadoPublicoSolicitudUseCaseTest {
+
+    private val repo: SolicitudEmpresaRepositoryPort = mockk()
+    private val useCase = ConsultarEstadoPublicoSolicitudUseCase(repo)
+
+    private fun solicitud(
+        estado: EstadoSolicitud,
+        comentarioAdmin: String? = null,
+        fechaRevision: LocalDateTime? = null
+    ) = SolicitudEmpresa(
+        id = 1L,
+        numeroSolicitud = "SOL-20260423-000001",
+        nombreEmpresa = "Empresa Test S.A.S.",
+        nitEmpresa = "900111222-1",
+        nombreContacto = "Juan Pérez",
+        cargoContacto = "Gerente",
+        correoContacto = "juan@empresa.com",
+        tipoDocumentoEstudiante = TipoDocumento.CC,
+        documentoEstudiante = "10350001",
+        nombreEstudiante = "Ana Gomez",
+        tipoValidacion = ValidationType.DEGREE,
+        aceptaTerminos = true,
+        rutaCarta = "uploads/carta.pdf",
+        estado = estado,
+        comentarioAdmin = comentarioAdmin,
+        fechaRevision = fechaRevision,
+        adminResponsable = if (fechaRevision != null) "admin" else null
+    )
+
+    // ── Use case devuelve el dominio sin transformar ───────────────────────────
+
+    @Test
+    fun `retorna la solicitud cuando existe`() {
+        every { repo.findByNumeroSolicitud("SOL-20260423-000001") } returns solicitud(EstadoSolicitud.PENDIENTE)
+
+        val result = useCase.execute("SOL-20260423-000001")
+
+        assertNotNull(result)
+        assertEquals("SOL-20260423-000001", result!!.numeroSolicitud)
+    }
+
+    @Test
+    fun `retorna null cuando la solicitud no existe`() {
+        every { repo.findByNumeroSolicitud(any()) } returns null
+
+        assertNull(useCase.execute("SOL-19990101-000001"))
+    }
+
+    // ── Lógica de privacidad en toPublicResponse ──────────────────────────────
+
+    @Test
+    fun `estado PENDIENTE no expone motivoRechazo ni campos sensibles`() {
+        every { repo.findByNumeroSolicitud(any()) } returns solicitud(EstadoSolicitud.PENDIENTE)
+
+        val response = useCase.execute("SOL-20260423-000001")!!.toPublicResponse()
+
+        assertEquals(EstadoSolicitud.PENDIENTE, response.estado)
+        assertNull(response.motivoRechazo)
+        assertNull(response.fechaRevision)
+        assertEquals("Empresa Test S.A.S.", response.nombreEmpresa)
+        assertEquals("Ana Gomez", response.nombreEstudiante)
+    }
+
+    @Test
+    fun `estado EN_REVISION no expone motivoRechazo`() {
+        val revision = LocalDateTime.now()
+        every { repo.findByNumeroSolicitud(any()) } returns solicitud(EstadoSolicitud.EN_REVISION, fechaRevision = revision)
+
+        val response = useCase.execute("SOL-20260423-000001")!!.toPublicResponse()
+
+        assertEquals(EstadoSolicitud.EN_REVISION, response.estado)
+        assertNull(response.motivoRechazo)
+        assertEquals(revision, response.fechaRevision)
+    }
+
+    @Test
+    fun `estado APROBADA no expone motivoRechazo aunque comentarioAdmin no sea null`() {
+        val revision = LocalDateTime.now()
+        every { repo.findByNumeroSolicitud(any()) } returns
+            solicitud(EstadoSolicitud.APROBADA, comentarioAdmin = "Aprobada sin observaciones", fechaRevision = revision)
+
+        val response = useCase.execute("SOL-20260423-000001")!!.toPublicResponse()
+
+        assertEquals(EstadoSolicitud.APROBADA, response.estado)
+        // comentarioAdmin del admin NO se revela aunque exista
+        assertNull(response.motivoRechazo)
+    }
+
+    @Test
+    fun `estado RECHAZADA expone motivoRechazo con el comentarioAdmin`() {
+        val revision = LocalDateTime.now()
+        every { repo.findByNumeroSolicitud(any()) } returns
+            solicitud(EstadoSolicitud.RECHAZADA, comentarioAdmin = "Documentación incompleta", fechaRevision = revision)
+
+        val response = useCase.execute("SOL-20260423-000001")!!.toPublicResponse()
+
+        assertEquals(EstadoSolicitud.RECHAZADA, response.estado)
+        assertEquals("Documentación incompleta", response.motivoRechazo)
+        assertEquals(revision, response.fechaRevision)
+    }
+}


### PR DESCRIPTION
## Contexto

Agrega un endpoint público mínimo para que una empresa pueda consultar el estado de su solicitud sin autenticación, con un DTO reducido que oculta datos sensibles. Complementa el ciclo completo del flujo empresa: el solicitante crea, el admin revisa, el solicitante consulta.

## Endpoint nuevo

GET /api/v1/public/solicitudes-empresa/{numero}/estado

- Sin JWT. Explícitamente permitido en `SecurityConfig`.
- Rate limit: 20 requests/min por IP (config bajo `app.rate-limit.rules`).
- Validación de formato del path variable con `@Pattern(regexp = "^SOL-\\d{8}-\\d{6}$")`.

## DTO reducido

`ConsultaPublicaSolicitudResponse` expone solo 7 campos:

- `numeroSolicitud`, `estado`, `createdAt`, `fechaRevision`
- `nombreEmpresa` (para que el consultante confirme que es su solicitud)
- `nombreEstudiante` (para confirmar el estudiante)
- `motivoRechazo` (SOLO si `estado == RECHAZADA`; en cualquier otro caso es `null` y se omite por Jackson si aplica null-exclusion)

## Campos omitidos intencionalmente

- `nit_empresa`, datos de contacto interno (nombre/correo/teléfono/cargo)
- `documentoEstudiante`, `programaConsultado`, `tipoValidacion`, `observaciones`
- `rutaCarta`, `aceptaTerminos`
- `comentarioAdmin` (excepto como `motivoRechazo` en caso de rechazo)
- **`adminResponsable`** (identidad del funcionario, nunca se expone públicamente)

## Arquitectura

- Use case nuevo `ConsultarEstadoPublicoSolicitudUseCase` devuelve `SolicitudEmpresa?` (modelo de dominio).
- El mapeo al DTO reducido vive en una función de extensión `SolicitudEmpresa.toPublicResponse()` en el mismo archivo del DTO. La lógica condicional de `motivoRechazo` concentra la política "qué revelar públicamente" en un solo lugar.
- Controller nuevo `ConsultaPublicaSolicitudController`. No toca el `SolicitudEmpresaController` existente.

## Cambios fuera de código nuevo

- `SecurityConfig.kt`: agregado `/api/v1/public/**` al bloque `permitAll()` existente.
- `application.yml`: nueva regla de rate limit para el prefix `/api/v1/public/solicitudes-empresa`.

## Tests

- **Unitarios (5):** un caso por estado (`PENDIENTE`, `EN_REVISION`, `APROBADA`, `RECHAZADA`) verificando que `motivoRechazo` solo aparece en `RECHAZADA`, más un caso de solicitud inexistente que devuelve `null`.
- **Integración (9):** HTTP 200 en los 4 estados validando campos visibles y **ausencia explícita de los campos sensibles en el JSON de respuesta**, HTTP 404 con número inexistente, HTTP 400 con formato inválido, acceso sin JWT.

Total: 14 tests nuevos. Tests existentes siguen pasando sin modificación.

## Validación

- [x] `./gradlew test --rerun-tasks` → BUILD SUCCESSFUL, 41s, 6 contextos Spring cerraron limpio.
- [x] Los tests de integración verifican explícitamente que los campos sensibles (`adminResponsable`, `documentoEstudiante`, `nit_empresa`, etc.) NO aparecen en el JSON de respuesta, no solo que el happy path funciona.
- [x] Sin regresiones en tests existentes.

## Consecuencia operativa

Ahora el frontend (cuando se construya la vista "consultar mi solicitud") tiene un endpoint seguro al cual apuntar. La empresa puede ver el estado sin exponer internals del sistema.

## Pendientes relacionados

Los Issues #8 (normalizar `validation_type`) y #9 (atomicidad disco/BD) siguen abiertos. No se tocan en este PR.