### PR TITLE
feat: Panel admin completo de solicitudes empresa (backend + frontend)

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -6,6 +6,7 @@ import Verificar from './pages/Verificar';
 import Historial from './pages/Historial';
 import Login from './pages/Login';
 import SolicitudEmpresa from './pages/SolicitudEmpresa';
+import AdminSolicitudes from './pages/AdminSolicitudes';
 import './index.css';
 
 export default function App() {
@@ -19,6 +20,7 @@ export default function App() {
         <Route path="/verificar" element={<Verificar />} />
         <Route path="/historial" element={<Historial />} />
         <Route path="/login" element={<Login />} />
+        <Route path="/admin/solicitudes" element={<AdminSolicitudes />} />
       </Routes>
     </BrowserRouter>
   );

--- a/frontend/src/api/api.js
+++ b/frontend/src/api/api.js
@@ -123,3 +123,34 @@ export const consultarSolicitud = (numero) =>
 /** URL directa para descarga de la plantilla .docx (enlace <a>, no llamada axios). */
 export const urlPlantillaCarta = () =>
   `${BASE_URL}/api/v1/solicitudes-empresa/recursos/plantilla-carta`;
+
+// Solicitudes empresa — Admin (requieren ROLE_ADMIN + JWT)
+
+export const listarSolicitudesAdmin = (page = 0, size = 20, estado = null) => {
+  const params = { page, size };
+  if (estado) params.estado = estado;
+  return api.get('/api/v1/admin/solicitudes-empresa', { params });
+};
+
+export const descargarCartaSolicitud = (numero) =>
+  api.get(`/api/v1/admin/solicitudes-empresa/${numero}/carta`, {
+    responseType: 'blob',
+  });
+
+export const marcarEnRevision = (numero, comentarioAdmin = null) =>
+  api.post(
+    `/api/v1/admin/solicitudes-empresa/${numero}/marcar-en-revision`,
+    { comentarioAdmin }
+  );
+
+export const aprobarSolicitud = (numero, comentarioAdmin = null) =>
+  api.post(
+    `/api/v1/admin/solicitudes-empresa/${numero}/aprobar`,
+    { comentarioAdmin }
+  );
+
+export const rechazarSolicitud = (numero, comentarioAdmin) =>
+  api.post(
+    `/api/v1/admin/solicitudes-empresa/${numero}/rechazar`,
+    { comentarioAdmin }
+  );

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -44,9 +44,14 @@ export default function Navbar() {
             Historial
           </NavLink>
           {isAdmin ? (
-            <button className="nav-link" style={{ background: 'none', border: 'none', cursor: 'pointer' }} onClick={handleLogout}>
-              Salir
-            </button>
+            <>
+              <NavLink to="/admin/solicitudes" className={({ isActive }) => isActive ? 'nav-link active' : 'nav-link'}>
+                Panel
+              </NavLink>
+              <button className="nav-link" style={{ background: 'none', border: 'none', cursor: 'pointer' }} onClick={handleLogout}>
+                Salir
+              </button>
+            </>
           ) : (
             <NavLink to="/login" className={({ isActive }) => isActive ? 'nav-link active' : 'nav-link'}>
               Admin

--- a/frontend/src/pages/AdminSolicitudes.css
+++ b/frontend/src/pages/AdminSolicitudes.css
@@ -1,0 +1,281 @@
+/* ── Badge de estado EN_REVISION (local — no tocar index.css) ─────────── */
+
+.badge-review {
+  background: rgba(251, 140, 0, 0.15);
+  color: #fb8c00;
+  border: 1px solid rgba(251, 140, 0, 0.3);
+}
+
+/* ── Overlay del modal ────────────────────────────────────────────────── */
+
+.modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.65);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  padding: 20px;
+  animation: fadeIn 0.15s ease;
+}
+
+.modal-box {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  box-shadow: 0 8px 48px rgba(0, 0, 0, 0.6);
+  max-width: 620px;
+  width: 100%;
+  max-height: 90vh;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+}
+
+.modal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 20px 24px 16px;
+  border-bottom: 1px solid var(--border);
+  gap: 12px;
+}
+
+.modal-header-left {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.modal-numero {
+  font-family: monospace;
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--text);
+  letter-spacing: 1px;
+}
+
+.modal-close {
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  cursor: pointer;
+  font-size: 1.2rem;
+  line-height: 1;
+  padding: 4px 8px;
+  border-radius: 6px;
+  transition: color 0.2s, background 0.2s;
+  flex-shrink: 0;
+  font-family: var(--font-body);
+}
+
+.modal-close:hover:not(:disabled) {
+  color: var(--text);
+  background: var(--surface2);
+}
+
+.modal-body {
+  padding: 20px 24px;
+  flex: 1;
+}
+
+.modal-section-title {
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 1.5px;
+  color: var(--accent);
+  margin: 20px 0 12px;
+  padding-bottom: 8px;
+  border-bottom: 1px solid var(--border);
+}
+
+.modal-section-title:first-child {
+  margin-top: 0;
+}
+
+.modal-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 12px 24px;
+}
+
+@media (max-width: 560px) {
+  .modal-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+.modal-field {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.modal-field-label {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.8px;
+  color: var(--text-muted);
+}
+
+.modal-field-value {
+  font-size: 14px;
+  color: var(--text);
+  word-break: break-word;
+}
+
+.modal-footer {
+  padding: 16px 24px 20px;
+  border-top: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.modal-actions {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+/* ── Botones de acción del modal ──────────────────────────────────────── */
+
+.btn-review {
+  background: rgba(251, 140, 0, 0.12);
+  border: 1px solid rgba(251, 140, 0, 0.3);
+  color: #fb8c00;
+}
+
+.btn-review:hover:not(:disabled) {
+  background: rgba(251, 140, 0, 0.22);
+}
+
+.btn-danger {
+  background: rgba(200, 16, 46, 0.12);
+  border: 1px solid rgba(200, 16, 46, 0.3);
+  color: var(--accent-light);
+}
+
+.btn-danger:hover:not(:disabled) {
+  background: rgba(200, 16, 46, 0.22);
+}
+
+/* ── Sub-formulario de rechazo ──────────────────────────────────────── */
+
+.rechazo-form {
+  background: var(--bg2);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.rechazo-form textarea {
+  width: 100%;
+  min-height: 90px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  color: var(--text);
+  font-family: var(--font-body);
+  font-size: 14px;
+  padding: 10px 14px;
+  resize: vertical;
+  outline: none;
+  transition: border-color 0.2s, box-shadow 0.2s;
+}
+
+.rechazo-form textarea:focus {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px rgba(200, 16, 46, 0.12);
+}
+
+.rechazo-actions {
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
+}
+
+/* ── Barra de filtro y contador ─────────────────────────────────────── */
+
+.as-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 20px;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.as-filter {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.as-filter label {
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  color: var(--text-muted);
+  white-space: nowrap;
+}
+
+/* ── Toast de feedback ──────────────────────────────────────────────── */
+
+.as-toast {
+  position: fixed;
+  top: 72px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 1100;
+  min-width: 280px;
+  max-width: 500px;
+  animation: fadeIn 0.25s ease;
+  pointer-events: none;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* ── Filas de la tabla clickeables ─────────────────────────────────── */
+
+.row-clickable {
+  cursor: pointer;
+}
+
+/* ── Botón de descarga carta ────────────────────────────────────────── */
+
+.btn-download {
+  background: transparent;
+  border: 1px solid var(--border);
+  color: var(--text-muted);
+  font-size: 13px;
+  padding: 8px 14px;
+  border-radius: 8px;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  transition: border-color 0.2s, color 0.2s;
+  font-family: var(--font-body);
+  font-weight: 500;
+}
+
+.btn-download:hover:not(:disabled) {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.btn-download:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}

--- a/frontend/src/pages/AdminSolicitudes.jsx
+++ b/frontend/src/pages/AdminSolicitudes.jsx
@@ -1,0 +1,472 @@
+import { useState, useEffect, useCallback, useRef } from 'react';
+import { useNavigate } from 'react-router-dom';
+import {
+  listarSolicitudesAdmin,
+  descargarCartaSolicitud,
+  marcarEnRevision,
+  aprobarSolicitud,
+  rechazarSolicitud,
+  extractErrorMessage,
+} from '../api/api';
+import './AdminSolicitudes.css';
+
+const PAGE_SIZE = 20;
+const ESTADOS = ['PENDIENTE', 'EN_REVISION', 'APROBADA', 'RECHAZADA'];
+
+function badgeClass(estado) {
+  switch (estado) {
+    case 'PENDIENTE':   return 'badge badge-pending';
+    case 'EN_REVISION': return 'badge badge-review';
+    case 'APROBADA':    return 'badge badge-valid';
+    case 'RECHAZADA':   return 'badge badge-invalid';
+    default:            return 'badge';
+  }
+}
+
+function fmt(dateStr) {
+  if (!dateStr) return '—';
+  return new Date(dateStr).toLocaleString('es-CO', {
+    year: 'numeric', month: '2-digit', day: '2-digit',
+    hour: '2-digit', minute: '2-digit',
+  });
+}
+
+function Field({ label, value }) {
+  return (
+    <div className="modal-field">
+      <span className="modal-field-label">{label}</span>
+      <span className="modal-field-value">{value || '—'}</span>
+    </div>
+  );
+}
+
+export default function AdminSolicitudes() {
+  const navigate = useNavigate();
+
+  // ── Lista ──────────────────────────────────────────────────────────
+  const [page, setPage]                   = useState(0);
+  const [pageData, setPageData]           = useState(null);
+  const [loading, setLoading]             = useState(true);
+  const [estadoFiltro, setEstadoFiltro]   = useState('');
+
+  // ── Toast ──────────────────────────────────────────────────────────
+  const [toast, setToast]                 = useState(null); // { type: 'success'|'error', msg }
+  const toastTimer                        = useRef(null);
+
+  // ── Modal ──────────────────────────────────────────────────────────
+  const [selected, setSelected]           = useState(null);
+  const [actionLoading, setActionLoading] = useState(false);
+
+  // ── Rechazo (sub-formulario dentro del modal) ──────────────────────
+  const [showRechazar, setShowRechazar]   = useState(false);
+  const [motivoRechazo, setMotivoRechazo] = useState('');
+
+  // ── Guard de token ─────────────────────────────────────────────────
+  useEffect(() => {
+    if (!localStorage.getItem('token')) navigate('/login');
+  }, [navigate]);
+
+  // ── Carga paginada con filtro (useCallback con estadoFiltro en deps) ─
+  const loadPage = useCallback((pageNum) => {
+    setLoading(true);
+    listarSolicitudesAdmin(pageNum, PAGE_SIZE, estadoFiltro || null)
+      .then((res) => {
+        setPageData(res.data);
+        setPage(pageNum);
+      })
+      .catch((err) => {
+        if (!err.response || err.response.status !== 401) {
+          showToast('error', extractErrorMessage(err, 'No se pudo cargar las solicitudes.'));
+        }
+      })
+      .finally(() => setLoading(false));
+  }, [estadoFiltro]);
+
+  // Se dispara en el montaje y cada vez que cambia estadoFiltro
+  useEffect(() => {
+    loadPage(0);
+  }, [loadPage]);
+
+  // ── ESC cierra el modal ────────────────────────────────────────────
+  useEffect(() => {
+    if (!selected) return;
+    const onKey = (e) => {
+      if (e.key === 'Escape' && !actionLoading) {
+        setSelected(null);
+        setShowRechazar(false);
+        setMotivoRechazo('');
+      }
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [selected, actionLoading]);
+
+  // ── Helpers ────────────────────────────────────────────────────────
+  function showToast(type, msg) {
+    if (toastTimer.current) clearTimeout(toastTimer.current);
+    setToast({ type, msg });
+    toastTimer.current = setTimeout(() => setToast(null), 4000);
+  }
+
+  function closeModal() {
+    setSelected(null);
+    setShowRechazar(false);
+    setMotivoRechazo('');
+  }
+
+  function openModal(sol) {
+    setSelected(sol);
+    setShowRechazar(false);
+    setMotivoRechazo('');
+  }
+
+  // ── Descarga de carta ──────────────────────────────────────────────
+  async function handleDescarga() {
+    setActionLoading(true);
+    try {
+      const res = await descargarCartaSolicitud(selected.numeroSolicitud);
+      const url = URL.createObjectURL(res.data);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `Carta_${selected.numeroSolicitud}.pdf`;
+      a.click();
+      URL.revokeObjectURL(url);
+    } catch (err) {
+      showToast('error', extractErrorMessage(err, 'No se pudo descargar la carta.'));
+    } finally {
+      setActionLoading(false);
+    }
+  }
+
+  // ── Acción de transición de estado (marcar en revisión / aprobar) ──
+  async function handleAction(apiFn, successMsg) {
+    setActionLoading(true);
+    try {
+      await apiFn();
+      showToast('success', successMsg);
+      closeModal();
+      loadPage(page);
+    } catch (err) {
+      showToast('error', extractErrorMessage(err, 'Error al procesar la acción.'));
+    } finally {
+      setActionLoading(false);
+    }
+  }
+
+  // ── Rechazar ────────────────────────────────────────────────────────
+  async function handleRechazar() {
+    await handleAction(
+      () => rechazarSolicitud(selected.numeroSolicitud, motivoRechazo.trim()),
+      'Solicitud rechazada correctamente.'
+    );
+  }
+
+  // ── Derivados ─────────────────────────────────────────────────────
+  const solicitudes   = pageData?.content ?? [];
+  const totalPages    = pageData?.totalPages ?? 0;
+  const totalElements = pageData?.totalElements ?? 0;
+  const from          = totalElements === 0 ? 0 : page * PAGE_SIZE + 1;
+  const to            = Math.min(page * PAGE_SIZE + solicitudes.length, totalElements);
+
+  const esEstadoFinal = selected?.estado === 'APROBADA' || selected?.estado === 'RECHAZADA';
+
+  // ── Render ─────────────────────────────────────────────────────────
+  return (
+    <div className="page fade-in">
+
+      {/* Header */}
+      <div className="page-header">
+        <h1>Solicitudes de Empresa</h1>
+        <p>Revisa, aprueba o rechaza las solicitudes de verificación académica enviadas por empresas.</p>
+      </div>
+
+      {/* Toast */}
+      {toast && (
+        <div className={`as-toast alert alert-${toast.type === 'success' ? 'success' : 'error'}`}>
+          {toast.type === 'success' ? '✓' : '⚠️'} {toast.msg}
+        </div>
+      )}
+
+      {/* Card: filtro + tabla + paginación */}
+      <div className="card">
+
+        <div className="as-toolbar">
+          <div className="as-filter">
+            <label htmlFor="filtro-estado">Estado</label>
+            <select
+              id="filtro-estado"
+              className="form-select"
+              style={{ width: 'auto', minWidth: 160 }}
+              value={estadoFiltro}
+              onChange={(e) => setEstadoFiltro(e.target.value)}
+            >
+              <option value="">Todos</option>
+              {ESTADOS.map((e) => (
+                <option key={e} value={e}>{e.replace('_', ' ')}</option>
+              ))}
+            </select>
+          </div>
+          {!loading && pageData && (
+            <span className="badge badge-pending">
+              {totalElements > 0 ? `${from}–${to} de ${totalElements}` : '0 solicitudes'}
+            </span>
+          )}
+        </div>
+
+        {loading && (
+          <div className="empty">
+            <div className="spinner" style={{ width: 32, height: 32, borderWidth: 3 }} />
+            <p style={{ marginTop: 16 }}>Cargando...</p>
+          </div>
+        )}
+
+        {!loading && solicitudes.length === 0 && (
+          <div className="empty">
+            <div className="empty-icon">📭</div>
+            <p>
+              No hay solicitudes
+              {estadoFiltro ? ` con estado ${estadoFiltro.replace('_', ' ')}` : ''} aún.
+            </p>
+          </div>
+        )}
+
+        {!loading && solicitudes.length > 0 && (
+          <>
+            <div className="table-wrap">
+              <table>
+                <thead>
+                  <tr>
+                    <th>N.° Radicado</th>
+                    <th>Empresa</th>
+                    <th>Estudiante</th>
+                    <th>Tipo</th>
+                    <th>Estado</th>
+                    <th>Fecha</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {solicitudes.map((s) => (
+                    <tr key={s.id} className="row-clickable" onClick={() => openModal(s)}>
+                      <td style={{ fontFamily: 'monospace', fontSize: 13 }}>{s.numeroSolicitud}</td>
+                      <td>{s.nombreEmpresa}</td>
+                      <td>{s.nombreEstudiante}</td>
+                      <td>{s.tipoValidacion}</td>
+                      <td>
+                        <span className={badgeClass(s.estado)}>
+                          {s.estado.replace('_', ' ')}
+                        </span>
+                      </td>
+                      <td style={{ fontSize: 13, color: 'var(--text-muted)' }}>{fmt(s.createdAt)}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+
+            {totalPages > 1 && (
+              <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', gap: 8, marginTop: 20 }}>
+                <button
+                  className="btn btn-outline"
+                  onClick={() => loadPage(0)}
+                  disabled={page === 0}
+                  style={{ padding: '6px 12px', fontSize: '0.85rem' }}
+                >
+                  «
+                </button>
+                <button
+                  className="btn btn-outline"
+                  onClick={() => loadPage(page - 1)}
+                  disabled={page === 0}
+                  style={{ padding: '6px 12px', fontSize: '0.85rem' }}
+                >
+                  ‹ Anterior
+                </button>
+                <span style={{ fontSize: '0.9rem', color: '#555', padding: '0 8px' }}>
+                  Página <strong>{page + 1}</strong> de <strong>{totalPages}</strong>
+                </span>
+                <button
+                  className="btn btn-outline"
+                  onClick={() => loadPage(page + 1)}
+                  disabled={page >= totalPages - 1}
+                  style={{ padding: '6px 12px', fontSize: '0.85rem' }}
+                >
+                  Siguiente ›
+                </button>
+                <button
+                  className="btn btn-outline"
+                  onClick={() => loadPage(totalPages - 1)}
+                  disabled={page >= totalPages - 1}
+                  style={{ padding: '6px 12px', fontSize: '0.85rem' }}
+                >
+                  »
+                </button>
+              </div>
+            )}
+          </>
+        )}
+      </div>
+
+      {/* Modal de detalle */}
+      {selected && (
+        <div
+          className="modal-overlay"
+          onClick={(e) => { if (e.target === e.currentTarget && !actionLoading) closeModal(); }}
+          role="dialog"
+          aria-modal="true"
+          aria-label={`Detalle solicitud ${selected.numeroSolicitud}`}
+        >
+          <div className="modal-box">
+
+            {/* Header del modal */}
+            <div className="modal-header">
+              <div className="modal-header-left">
+                <span className="modal-numero">{selected.numeroSolicitud}</span>
+                <span className={badgeClass(selected.estado)}>
+                  {selected.estado.replace('_', ' ')}
+                </span>
+              </div>
+              <button
+                className="modal-close"
+                onClick={closeModal}
+                disabled={actionLoading}
+                aria-label="Cerrar"
+              >
+                ✕
+              </button>
+            </div>
+
+            {/* Cuerpo del modal */}
+            <div className="modal-body">
+
+              <p className="modal-section-title">Empresa</p>
+              <div className="modal-grid">
+                <Field label="Nombre empresa" value={selected.nombreEmpresa} />
+                <Field label="NIT" value={selected.nitEmpresa} />
+                <Field label="Contacto" value={selected.nombreContacto} />
+                <Field label="Cargo" value={selected.cargoContacto} />
+                <Field label="Correo contacto" value={selected.correoContacto} />
+              </div>
+
+              <p className="modal-section-title">Estudiante</p>
+              <div className="modal-grid">
+                <Field label="Nombre" value={selected.nombreEstudiante} />
+                <Field
+                  label={`Documento (${selected.tipoDocumentoEstudiante})`}
+                  value={selected.documentoEstudiante}
+                />
+                <Field label="Tipo validación" value={selected.tipoValidacion} />
+              </div>
+
+              <p className="modal-section-title">Revisión</p>
+              <div className="modal-grid">
+                <Field label="Fecha solicitud" value={fmt(selected.createdAt)} />
+                <Field label="Fecha revisión" value={fmt(selected.fechaRevision)} />
+                <Field label="Admin responsable" value={selected.adminResponsable} />
+                {selected.comentarioAdmin && (
+                  <div className="modal-field" style={{ gridColumn: '1 / -1' }}>
+                    <span className="modal-field-label">Comentario admin</span>
+                    <span className="modal-field-value">{selected.comentarioAdmin}</span>
+                  </div>
+                )}
+              </div>
+
+              <div style={{ marginTop: 20 }}>
+                <button
+                  className="btn-download"
+                  onClick={handleDescarga}
+                  disabled={actionLoading}
+                >
+                  {actionLoading
+                    ? <span className="spinner" style={{ width: 14, height: 14, borderWidth: 2 }} />
+                    : '⬇'
+                  }
+                  Descargar carta PDF
+                </button>
+              </div>
+            </div>
+
+            {/* Footer: botones contextuales según estado */}
+            {!esEstadoFinal && (
+              <div className="modal-footer">
+
+                {!showRechazar && (
+                  <div className="modal-actions">
+                    {selected.estado === 'PENDIENTE' && (
+                      <button
+                        className="btn btn-review"
+                        disabled={actionLoading}
+                        onClick={() =>
+                          handleAction(
+                            () => marcarEnRevision(selected.numeroSolicitud),
+                            'Solicitud marcada en revisión.'
+                          )
+                        }
+                      >
+                        Marcar en revisión
+                      </button>
+                    )}
+                    <button
+                      className="btn btn-success"
+                      disabled={actionLoading}
+                      onClick={() =>
+                        handleAction(
+                          () => aprobarSolicitud(selected.numeroSolicitud),
+                          'Solicitud aprobada correctamente.'
+                        )
+                      }
+                    >
+                      Aprobar
+                    </button>
+                    <button
+                      className="btn btn-danger"
+                      disabled={actionLoading}
+                      onClick={() => setShowRechazar(true)}
+                    >
+                      Rechazar
+                    </button>
+                    {actionLoading && (
+                      <span className="spinner" style={{ width: 18, height: 18, borderWidth: 2 }} />
+                    )}
+                  </div>
+                )}
+
+                {showRechazar && (
+                  <div className="rechazo-form">
+                    <textarea
+                      placeholder="Motivo del rechazo (obligatorio)"
+                      value={motivoRechazo}
+                      onChange={(e) => setMotivoRechazo(e.target.value)}
+                      disabled={actionLoading}
+                    />
+                    <div className="rechazo-actions">
+                      <button
+                        className="btn btn-outline"
+                        onClick={() => { setShowRechazar(false); setMotivoRechazo(''); }}
+                        disabled={actionLoading}
+                      >
+                        Cancelar
+                      </button>
+                      <button
+                        className="btn btn-danger"
+                        onClick={handleRechazar}
+                        disabled={actionLoading || !motivoRechazo.trim()}
+                      >
+                        {actionLoading
+                          ? <span className="spinner" style={{ width: 14, height: 14, borderWidth: 2 }} />
+                          : 'Confirmar rechazo'
+                        }
+                      </button>
+                    </div>
+                  </div>
+                )}
+
+              </div>
+            )}
+
+          </div>
+        </div>
+      )}
+
+    </div>
+  );
+}

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -18,7 +18,7 @@ export default function Login() {
       const token = res.data?.token || res.data?.accessToken || res.data;
       if (!token || typeof token !== 'string') throw new Error('Token inválido');
       localStorage.setItem('token', token);
-      navigate('/historial');
+      navigate('/admin/solicitudes');
     } catch (err) {
       if (err.response?.status === 401 || err.response?.status === 403) {
         setError('Credenciales incorrectas. Verifique usuario y contraseña.');
@@ -42,8 +42,9 @@ export default function Login() {
       <div className="card">
         <form onSubmit={handleSubmit}>
           <div className="form-group">
-            <label className="form-label">Usuario</label>
+            <label className="form-label" htmlFor="login-username">Usuario</label>
             <input
+              id="login-username"
               className="form-input"
               type="text"
               value={username}
@@ -54,8 +55,9 @@ export default function Login() {
           </div>
 
           <div className="form-group">
-            <label className="form-label">Contraseña</label>
+            <label className="form-label" htmlFor="login-password">Contraseña</label>
             <input
+              id="login-password"
               className="form-input"
               type="password"
               value={password}

--- a/frontend/src/test/AdminSolicitudes.test.jsx
+++ b/frontend/src/test/AdminSolicitudes.test.jsx
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import AdminSolicitudes from '../pages/AdminSolicitudes';
+
+vi.mock('../api/api', () => ({
+  listarSolicitudesAdmin: vi.fn(),
+  descargarCartaSolicitud: vi.fn(),
+  marcarEnRevision: vi.fn(),
+  aprobarSolicitud: vi.fn(),
+  rechazarSolicitud: vi.fn(),
+  extractErrorMessage: vi.fn((err, fallback) => fallback || 'Error'),
+}));
+
+const mockNavigate = vi.fn();
+vi.mock('react-router-dom', async (importOriginal) => {
+  const actual = await importOriginal();
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+
+import { listarSolicitudesAdmin } from '../api/api';
+
+const EMPTY_PAGE = {
+  content: [],
+  totalElements: 0,
+  totalPages: 0,
+  currentPage: 0,
+  pageSize: 20,
+};
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <AdminSolicitudes />
+    </MemoryRouter>
+  );
+}
+
+describe('AdminSolicitudes', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+  });
+
+  it('redirige a /login si no hay token', () => {
+    listarSolicitudesAdmin.mockResolvedValueOnce({ data: EMPTY_PAGE });
+    renderPage();
+    expect(mockNavigate).toHaveBeenCalledWith('/login');
+  });
+
+  it('muestra estado vacío cuando la API devuelve lista vacía', async () => {
+    localStorage.setItem('token', 'tok');
+    listarSolicitudesAdmin.mockResolvedValueOnce({ data: EMPTY_PAGE });
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText(/no hay solicitudes/i)).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/test/Historial.test.jsx
+++ b/frontend/src/test/Historial.test.jsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, waitFor, within } from '@testing-library/react';
+import { render, screen, waitFor, within, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 import Historial from '../pages/Historial';
@@ -30,37 +30,42 @@ const PAGE_1 = {
   pageSize: 20,
 };
 
-function renderHistorial() {
-  return render(
-    <MemoryRouter>
-      <Historial />
-    </MemoryRouter>
-  );
+async function renderHistorial() {
+  await act(async () => {
+    render(
+      <MemoryRouter>
+        <Historial />
+      </MemoryRouter>
+    );
+  });
 }
 
 describe('Historial', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // Reset once-queues — vi.clearAllMocks() clears call records but NOT queued return values
+    listarEstudiantes.mockReset();
+    buscarEstudiantePorDocumento.mockReset();
     localStorage.clear();
   });
 
-  it('redirige a /login si no hay token en localStorage', () => {
-    listarEstudiantes.mockResolvedValueOnce({ data: PAGE_1 });
-    renderHistorial();
+  it('redirige a /login si no hay token en localStorage', async () => {
+    // No token → loadPage is never called, no API mock needed
+    await renderHistorial();
     expect(mockNavigate).toHaveBeenCalledWith('/login');
   });
 
   it('muestra spinner mientras carga', () => {
     localStorage.setItem('token', 'tok');
     listarEstudiantes.mockReturnValueOnce(new Promise(() => {})); // nunca resuelve
-    renderHistorial();
+    render(<MemoryRouter><Historial /></MemoryRouter>);
     expect(screen.getByText(/cargando/i)).toBeInTheDocument();
   });
 
   it('renderiza la tabla con los estudiantes tras carga exitosa', async () => {
     localStorage.setItem('token', 'tok');
     listarEstudiantes.mockResolvedValueOnce({ data: PAGE_1 });
-    renderHistorial();
+    await renderHistorial();
 
     await waitFor(() => {
       expect(screen.getByText('Laura Martínez')).toBeInTheDocument();
@@ -72,7 +77,7 @@ describe('Historial', () => {
   it('muestra el estado de cada estudiante con badge correcto', async () => {
     localStorage.setItem('token', 'tok');
     listarEstudiantes.mockResolvedValueOnce({ data: PAGE_1 });
-    renderHistorial();
+    await renderHistorial();
 
     await waitFor(() => screen.getByText('Laura Martínez'));
 
@@ -85,7 +90,7 @@ describe('Historial', () => {
   it('muestra el contador "1–3 de 3"', async () => {
     localStorage.setItem('token', 'tok');
     listarEstudiantes.mockResolvedValueOnce({ data: PAGE_1 });
-    renderHistorial();
+    await renderHistorial();
 
     await waitFor(() => {
       expect(screen.getByText('1–3 de 3')).toBeInTheDocument();
@@ -97,7 +102,7 @@ describe('Historial', () => {
     listarEstudiantes.mockResolvedValueOnce({
       data: { content: [], totalElements: 0, totalPages: 0, currentPage: 0, pageSize: 20 },
     });
-    renderHistorial();
+    await renderHistorial();
 
     await waitFor(() => {
       expect(screen.getByText(/no hay estudiantes registrados/i)).toBeInTheDocument();
@@ -107,7 +112,7 @@ describe('Historial', () => {
   it('muestra error cuando la API falla', async () => {
     localStorage.setItem('token', 'tok');
     listarEstudiantes.mockRejectedValueOnce({ response: { status: 500 } });
-    renderHistorial();
+    await renderHistorial();
 
     await waitFor(() => {
       expect(screen.getByText(/no se pudo cargar el historial/i)).toBeInTheDocument();
@@ -122,7 +127,7 @@ describe('Historial', () => {
     });
 
     const user = userEvent.setup();
-    renderHistorial();
+    await renderHistorial();
     await waitFor(() => screen.getByText('Laura Martínez'));
 
     await user.type(screen.getByPlaceholderText(/buscar por número de documento/i), '20240001');
@@ -140,7 +145,7 @@ describe('Historial', () => {
     buscarEstudiantePorDocumento.mockRejectedValueOnce({ response: { status: 404 } });
 
     const user = userEvent.setup();
-    renderHistorial();
+    await renderHistorial();
     await waitFor(() => screen.getByText('Laura Martínez'));
 
     await user.type(screen.getByPlaceholderText(/buscar por número de documento/i), '99999');
@@ -156,7 +161,7 @@ describe('Historial', () => {
     listarEstudiantes.mockResolvedValueOnce({
       data: { ...PAGE_1, totalElements: 45, totalPages: 3, pageSize: 20 },
     });
-    renderHistorial();
+    await renderHistorial();
 
     await waitFor(() => screen.getByText('Laura Martínez'));
 

--- a/frontend/src/test/Login.test.jsx
+++ b/frontend/src/test/Login.test.jsx
@@ -45,7 +45,7 @@ describe('Login', () => {
     expect(screen.getByRole('button', { name: /iniciar sesión/i })).toBeDisabled();
   });
 
-  it('guarda el token y navega a /historial tras login exitoso', async () => {
+  it('guarda el token y navega a /admin/solicitudes tras login exitoso', async () => {
     login.mockResolvedValueOnce({ data: { token: 'jwt-token-123' } });
     const user = userEvent.setup();
     renderLogin();
@@ -56,7 +56,7 @@ describe('Login', () => {
 
     await waitFor(() => {
       expect(localStorage.getItem('token')).toBe('jwt-token-123');
-      expect(mockNavigate).toHaveBeenCalledWith('/historial');
+      expect(mockNavigate).toHaveBeenCalledWith('/admin/solicitudes');
     });
   });
 

--- a/frontend/src/test/setup.js
+++ b/frontend/src/test/setup.js
@@ -1,1 +1,6 @@
 import '@testing-library/jest-dom';
+import { cleanup } from '@testing-library/react';
+import { afterEach } from 'vitest';
+
+// Explicit cleanup — @testing-library/react auto-cleanup doesn't always fire in Vitest 3.2
+afterEach(() => cleanup());

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -3,6 +3,10 @@ import react from '@vitejs/plugin-react'
 
 export default defineConfig({
   plugins: [react()],
+  esbuild: {
+    jsx: 'automatic',
+    jsxImportSource: 'react',
+  },
   server: {
     port: 3000,
     strictPort: true,
@@ -17,6 +21,7 @@ export default defineConfig({
     environment: 'jsdom',
     globals: true,
     setupFiles: ['./src/test/setup.js'],
+    testTimeout: 15000,
     coverage: {
       provider: 'v8',
       reporter: ['text', 'html'],

--- a/src/main/kotlin/co/edu/udemedellin/validacionacademica/application/usecase/DescargarCartaSolicitudUseCase.kt
+++ b/src/main/kotlin/co/edu/udemedellin/validacionacademica/application/usecase/DescargarCartaSolicitudUseCase.kt
@@ -1,0 +1,38 @@
+package co.edu.udemedellin.validacionacademica.application.usecase
+
+import co.edu.udemedellin.validacionacademica.domain.ports.FileStoragePort
+import co.edu.udemedellin.validacionacademica.domain.ports.SolicitudEmpresaRepositoryPort
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.nio.file.NoSuchFileException
+
+@Service
+class DescargarCartaSolicitudUseCase(
+    private val solicitudEmpresaRepositoryPort: SolicitudEmpresaRepositoryPort,
+    private val fileStoragePort: FileStoragePort
+) {
+    private val log = LoggerFactory.getLogger(DescargarCartaSolicitudUseCase::class.java)
+
+    /**
+     * Carga y devuelve los bytes de la carta adjunta a la solicitud.
+     *
+     * @throws NoSuchElementException   si no existe solicitud con ese número → HTTP 404.
+     * @throws IllegalArgumentException si el archivo físico no está disponible → HTTP 400.
+     */
+    @Transactional(readOnly = true)
+    fun execute(numeroSolicitud: String): ByteArray {
+        val solicitud = solicitudEmpresaRepositoryPort.findByNumeroSolicitud(numeroSolicitud)
+            ?: throw NoSuchElementException("Solicitud no encontrada: $numeroSolicitud")
+
+        return try {
+            fileStoragePort.loadAsBytes(solicitud.rutaCarta)
+        } catch (e: NoSuchFileException) {
+            log.error("Carta no encontrada en disco para solicitud {}: {}", numeroSolicitud, solicitud.rutaCarta)
+            throw IllegalArgumentException(
+                "La carta asociada a la solicitud $numeroSolicitud no está disponible en el " +
+                "sistema de archivos. Contacta al administrador."
+            )
+        }
+    }
+}

--- a/src/main/kotlin/co/edu/udemedellin/validacionacademica/application/usecase/ListarSolicitudesEmpresaUseCase.kt
+++ b/src/main/kotlin/co/edu/udemedellin/validacionacademica/application/usecase/ListarSolicitudesEmpresaUseCase.kt
@@ -1,0 +1,32 @@
+package co.edu.udemedellin.validacionacademica.application.usecase
+
+import co.edu.udemedellin.validacionacademica.domain.model.EstadoSolicitud
+import co.edu.udemedellin.validacionacademica.domain.model.SolicitudEmpresa
+import co.edu.udemedellin.validacionacademica.domain.ports.SolicitudEmpresaRepositoryPort
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Sort
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class ListarSolicitudesEmpresaUseCase(
+    private val solicitudEmpresaRepositoryPort: SolicitudEmpresaRepositoryPort
+) {
+    /**
+     * Retorna una página de solicitudes ordenada por `createdAt` DESC.
+     *
+     * @param page   número de página (base 0).
+     * @param size   tamaño de página (1–100).
+     * @param estado filtro opcional por estado; null devuelve todas.
+     */
+    @Transactional(readOnly = true)
+    fun execute(page: Int, size: Int, estado: EstadoSolicitud?): Page<SolicitudEmpresa> {
+        val pageable = PageRequest.of(
+            page,
+            size,
+            Sort.by(Sort.Direction.DESC, "createdAt")
+        )
+        return solicitudEmpresaRepositoryPort.findAll(pageable, estado)
+    }
+}

--- a/src/main/kotlin/co/edu/udemedellin/validacionacademica/domain/ports/SolicitudEmpresaRepositoryPort.kt
+++ b/src/main/kotlin/co/edu/udemedellin/validacionacademica/domain/ports/SolicitudEmpresaRepositoryPort.kt
@@ -1,6 +1,9 @@
 package co.edu.udemedellin.validacionacademica.domain.ports
 
+import co.edu.udemedellin.validacionacademica.domain.model.EstadoSolicitud
 import co.edu.udemedellin.validacionacademica.domain.model.SolicitudEmpresa
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 import java.time.LocalDate
 
 /**
@@ -36,4 +39,12 @@ interface SolicitudEmpresaRepositoryPort {
      * Usado para cambios de estado administrativos.
      */
     fun update(solicitud: SolicitudEmpresa): SolicitudEmpresa
+
+    /**
+     * Retorna una página de solicitudes ordenada por [SolicitudEmpresa.createdAt] DESC.
+     *
+     * @param pageable configuración de paginado y orden.
+     * @param estado   filtro opcional por estado; si es null se devuelven todas.
+     */
+    fun findAll(pageable: Pageable, estado: EstadoSolicitud?): Page<SolicitudEmpresa>
 }

--- a/src/main/kotlin/co/edu/udemedellin/validacionacademica/infrastructure/persistence/adapter/SolicitudEmpresaPersistenceAdapter.kt
+++ b/src/main/kotlin/co/edu/udemedellin/validacionacademica/infrastructure/persistence/adapter/SolicitudEmpresaPersistenceAdapter.kt
@@ -1,9 +1,12 @@
 package co.edu.udemedellin.validacionacademica.infrastructure.persistence.adapter
 
+import co.edu.udemedellin.validacionacademica.domain.model.EstadoSolicitud
 import co.edu.udemedellin.validacionacademica.domain.model.SolicitudEmpresa
 import co.edu.udemedellin.validacionacademica.domain.ports.SolicitudEmpresaRepositoryPort
 import co.edu.udemedellin.validacionacademica.infrastructure.persistence.entity.SolicitudEmpresaEntity
 import co.edu.udemedellin.validacionacademica.infrastructure.persistence.repository.SolicitudEmpresaJpaRepository
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Component
 import java.time.LocalDate
 
@@ -20,6 +23,15 @@ class SolicitudEmpresaPersistenceAdapter(
 
     override fun update(solicitud: SolicitudEmpresa): SolicitudEmpresa =
         jpaRepository.save(solicitud.toEntity()).toDomain()
+
+    override fun findAll(pageable: Pageable, estado: EstadoSolicitud?): Page<SolicitudEmpresa> {
+        val page = if (estado != null) {
+            jpaRepository.findByEstado(estado, pageable)
+        } else {
+            jpaRepository.findAll(pageable)
+        }
+        return page.map { it.toDomain() }
+    }
 
     override fun findMaxNumeroSolicitudByFecha(fecha: LocalDate): String? {
         val startOfDay = fecha.atStartOfDay()

--- a/src/main/kotlin/co/edu/udemedellin/validacionacademica/infrastructure/persistence/repository/SolicitudEmpresaJpaRepository.kt
+++ b/src/main/kotlin/co/edu/udemedellin/validacionacademica/infrastructure/persistence/repository/SolicitudEmpresaJpaRepository.kt
@@ -1,6 +1,9 @@
 package co.edu.udemedellin.validacionacademica.infrastructure.persistence.repository
 
+import co.edu.udemedellin.validacionacademica.domain.model.EstadoSolicitud
 import co.edu.udemedellin.validacionacademica.infrastructure.persistence.entity.SolicitudEmpresaEntity
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
@@ -9,6 +12,8 @@ import java.time.LocalDateTime
 interface SolicitudEmpresaJpaRepository : JpaRepository<SolicitudEmpresaEntity, Long> {
 
     fun findByNumeroSolicitud(numeroSolicitud: String): SolicitudEmpresaEntity?
+
+    fun findByEstado(estado: EstadoSolicitud, pageable: Pageable): Page<SolicitudEmpresaEntity>
 
     /**
      * Retorna el número de solicitud (`SOL-YYYYMMDD-NNNNNN`) más alto cuyo

--- a/src/main/kotlin/co/edu/udemedellin/validacionacademica/infrastructure/rest/controller/AdminSolicitudEmpresaController.kt
+++ b/src/main/kotlin/co/edu/udemedellin/validacionacademica/infrastructure/rest/controller/AdminSolicitudEmpresaController.kt
@@ -1,21 +1,34 @@
 package co.edu.udemedellin.validacionacademica.infrastructure.rest.controller
 
 import co.edu.udemedellin.validacionacademica.application.usecase.AprobarSolicitudEmpresaUseCase
+import co.edu.udemedellin.validacionacademica.application.usecase.DescargarCartaSolicitudUseCase
+import co.edu.udemedellin.validacionacademica.application.usecase.ListarSolicitudesEmpresaUseCase
 import co.edu.udemedellin.validacionacademica.application.usecase.MarcarEnRevisionUseCase
 import co.edu.udemedellin.validacionacademica.application.usecase.RechazarSolicitudEmpresaUseCase
+import co.edu.udemedellin.validacionacademica.domain.model.EstadoSolicitud
 import co.edu.udemedellin.validacionacademica.infrastructure.rest.dto.RevisionAdminRequest
 import co.edu.udemedellin.validacionacademica.infrastructure.rest.dto.SolicitudEmpresaResponse
 import co.edu.udemedellin.validacionacademica.infrastructure.rest.dto.toResponse
 import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.security.SecurityRequirement
 import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.constraints.Max
+import jakarta.validation.constraints.Min
 import org.slf4j.LoggerFactory
+import org.springframework.data.domain.Page
+import org.springframework.http.ContentDisposition
+import org.springframework.http.HttpHeaders
+import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.Authentication
+import org.springframework.validation.annotation.Validated
+import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 
 /**
@@ -28,12 +41,68 @@ import org.springframework.web.bind.annotation.RestController
 @RequestMapping("/api/v1/admin/solicitudes-empresa")
 @Tag(name = "Admin — Solicitudes Empresa", description = "Revisión y resolución de solicitudes de verificación por empresa")
 @SecurityRequirement(name = "bearerAuth")
+@Validated
 class AdminSolicitudEmpresaController(
     private val marcarEnRevisionUseCase: MarcarEnRevisionUseCase,
     private val aprobarSolicitudEmpresaUseCase: AprobarSolicitudEmpresaUseCase,
-    private val rechazarSolicitudEmpresaUseCase: RechazarSolicitudEmpresaUseCase
+    private val rechazarSolicitudEmpresaUseCase: RechazarSolicitudEmpresaUseCase,
+    private val listarSolicitudesEmpresaUseCase: ListarSolicitudesEmpresaUseCase,
+    private val descargarCartaSolicitudUseCase: DescargarCartaSolicitudUseCase
 ) {
     private val log = LoggerFactory.getLogger(AdminSolicitudEmpresaController::class.java)
+
+    // ── GET /api/v1/admin/solicitudes-empresa ─────────────────────────────────
+
+    @GetMapping
+    @Operation(
+        summary = "Listar solicitudes de empresa",
+        description = """Retorna una página de solicitudes ordenada por fecha de creación (más recientes primero).
+
+**Parámetros opcionales:**
+- `estado`: filtro por estado (`PENDIENTE`, `EN_REVISION`, `APROBADA`, `RECHAZADA`). Omitir para ver todas.
+- `page`: número de página, base 0 (por defecto 0).
+- `size`: registros por página, entre 1 y 100 (por defecto 20)."""
+    )
+    fun listar(
+        @Parameter(description = "Número de página (base 0)", example = "0")
+        @RequestParam(defaultValue = "0") @Min(0) page: Int,
+        @Parameter(description = "Tamaño de página (1–100)", example = "20")
+        @RequestParam(defaultValue = "20") @Min(1) @Max(100) size: Int,
+        @Parameter(description = "Filtro por estado (opcional)")
+        @RequestParam(required = false) estado: String?
+    ): ResponseEntity<Page<SolicitudEmpresaResponse>> {
+        log.info("Listar solicitudes: page={}, size={}, estado={}", page, size, estado)
+        val estadoEnum = parseEstado(estado)
+        val solicitudes = listarSolicitudesEmpresaUseCase.execute(page, size, estadoEnum)
+        return ResponseEntity.ok(solicitudes.map { it.toResponse() })
+    }
+
+    // ── GET /api/v1/admin/solicitudes-empresa/{numero}/carta ──────────────────
+
+    @GetMapping("/{numero}/carta")
+    @Operation(
+        summary = "Descargar carta de autorización",
+        description = """Descarga el PDF de la carta de autorización adjunta a la solicitud.
+
+- HTTP 404 si no existe solicitud con ese número.
+- HTTP 400 si el archivo no está disponible en el sistema de archivos."""
+    )
+    fun descargarCarta(
+        @Parameter(description = "Número de radicado", example = "SOL-20260423-000001")
+        @PathVariable numero: String
+    ): ResponseEntity<ByteArray> {
+        log.info("Descargar carta: {}", numero)
+        val bytes = descargarCartaSolicitudUseCase.execute(numero)
+        val headers = HttpHeaders().apply {
+            contentType = MediaType.APPLICATION_PDF
+            contentDisposition = ContentDisposition.attachment()
+                .filename("Carta_$numero.pdf")
+                .build()
+        }
+        return ResponseEntity.ok().headers(headers).body(bytes)
+    }
+
+    // ── POST — transiciones de estado ─────────────────────────────────────────
 
     @PostMapping("/{numero}/marcar-en-revision")
     @Operation(
@@ -95,5 +164,15 @@ class AdminSolicitudEmpresaController(
             adminUsername = authentication.name
         )
         return ResponseEntity.ok(solicitud.toResponse())
+    }
+
+    // ── Utilidades privadas ───────────────────────────────────────────────────
+
+    private fun parseEstado(estadoStr: String?): EstadoSolicitud? {
+        if (estadoStr.isNullOrBlank()) return null
+        return runCatching { EstadoSolicitud.valueOf(estadoStr) }.getOrElse {
+            val valid = EstadoSolicitud.values().joinToString(", ")
+            throw IllegalArgumentException("Estado inválido: '$estadoStr'. Valores válidos: $valid")
+        }
     }
 }

--- a/src/test/kotlin/co/edu/udemedellin/validacionacademica/controller/AdminSolicitudEmpresaControllerIntegrationTest.kt
+++ b/src/test/kotlin/co/edu/udemedellin/validacionacademica/controller/AdminSolicitudEmpresaControllerIntegrationTest.kt
@@ -13,8 +13,10 @@ import org.springframework.security.test.context.support.WithMockUser
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.TestPropertySource
 import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.header
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import org.springframework.transaction.annotation.Transactional
@@ -259,5 +261,75 @@ class AdminSolicitudEmpresaControllerIntegrationTest {
             post("/api/v1/admin/solicitudes-empresa/SOL-20260422-000001/marcar-en-revision")
                 .contentType(MediaType.APPLICATION_JSON).content("{}")
         ).andExpect(status().isForbidden)
+    }
+
+    // ── GET /api/v1/admin/solicitudes-empresa ─────────────────────────────────
+
+    @Test
+    @WithMockUser(roles = ["ADMIN"])
+    fun `listar sin filtro devuelve 200 con solicitudes y totalElements`() {
+        crearSolicitudYObtenerNumero()
+        crearSolicitudYObtenerNumero()
+
+        mockMvc.perform(get("/api/v1/admin/solicitudes-empresa"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.totalElements").value(org.hamcrest.Matchers.greaterThanOrEqualTo(2)))
+            .andExpect(jsonPath("$.content").isArray)
+    }
+
+    @Test
+    @WithMockUser(roles = ["ADMIN"])
+    fun `listar con filtro estado PENDIENTE devuelve solo solicitudes PENDIENTE`() {
+        crearSolicitudYObtenerNumero()
+
+        mockMvc.perform(
+            get("/api/v1/admin/solicitudes-empresa").param("estado", "PENDIENTE")
+        )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.content[0].estado").value("PENDIENTE"))
+    }
+
+    @Test
+    @WithMockUser(roles = ["ADMIN"])
+    fun `listar con estado invalido devuelve 400 con valores validos en mensaje`() {
+        mockMvc.perform(
+            get("/api/v1/admin/solicitudes-empresa").param("estado", "INVALIDO")
+        )
+            .andExpect(status().isBadRequest)
+            .andExpect(jsonPath("$.message").value(org.hamcrest.Matchers.containsString("PENDIENTE")))
+    }
+
+    @Test
+    fun `listar sin JWT devuelve 401`() {
+        mockMvc.perform(get("/api/v1/admin/solicitudes-empresa"))
+            .andExpect(status().isUnauthorized)
+    }
+
+    // ── GET /api/v1/admin/solicitudes-empresa/{numero}/carta ──────────────────
+
+    @Test
+    @WithMockUser(roles = ["ADMIN"])
+    fun `descargar carta existente devuelve 200 con Content-Type pdf y Content-Disposition attachment`() {
+        val numero = crearSolicitudYObtenerNumero()
+
+        mockMvc.perform(get("/api/v1/admin/solicitudes-empresa/$numero/carta"))
+            .andExpect(status().isOk)
+            .andExpect(header().string("Content-Type", org.hamcrest.Matchers.containsString("application/pdf")))
+            .andExpect(header().string("Content-Disposition", org.hamcrest.Matchers.containsString("attachment")))
+            .andExpect(header().string("Content-Disposition", org.hamcrest.Matchers.containsString("filename=")))
+            .andExpect(header().string("Content-Disposition", org.hamcrest.Matchers.containsString("Carta_$numero")))
+    }
+
+    @Test
+    @WithMockUser(roles = ["ADMIN"])
+    fun `descargar carta con numero inexistente devuelve 404`() {
+        mockMvc.perform(get("/api/v1/admin/solicitudes-empresa/SOL-19990101-999999/carta"))
+            .andExpect(status().isNotFound)
+    }
+
+    @Test
+    fun `descargar carta sin JWT devuelve 401`() {
+        mockMvc.perform(get("/api/v1/admin/solicitudes-empresa/SOL-20260422-000001/carta"))
+            .andExpect(status().isUnauthorized)
     }
 }

--- a/src/test/kotlin/co/edu/udemedellin/validacionacademica/usecase/ConsultarEstadoPublicoSolicitudUseCaseTest.kt
+++ b/src/test/kotlin/co/edu/udemedellin/validacionacademica/usecase/ConsultarEstadoPublicoSolicitudUseCaseTest.kt
@@ -1,4 +1,4 @@
-git commit -m "feat: endpoint publico de consulta de estado de solicitud empresa"package co.edu.udemedellin.validacionacademica.usecase
+package co.edu.udemedellin.validacionacademica.usecase
 
 import co.edu.udemedellin.validacionacademica.application.usecase.ConsultarEstadoPublicoSolicitudUseCase
 import co.edu.udemedellin.validacionacademica.domain.model.*

--- a/src/test/kotlin/co/edu/udemedellin/validacionacademica/usecase/DescargarCartaSolicitudUseCaseTest.kt
+++ b/src/test/kotlin/co/edu/udemedellin/validacionacademica/usecase/DescargarCartaSolicitudUseCaseTest.kt
@@ -1,0 +1,71 @@
+package co.edu.udemedellin.validacionacademica.usecase
+
+import co.edu.udemedellin.validacionacademica.application.usecase.DescargarCartaSolicitudUseCase
+import co.edu.udemedellin.validacionacademica.domain.model.*
+import co.edu.udemedellin.validacionacademica.domain.ports.FileStoragePort
+import co.edu.udemedellin.validacionacademica.domain.ports.SolicitudEmpresaRepositoryPort
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.nio.file.NoSuchFileException
+
+class DescargarCartaSolicitudUseCaseTest {
+
+    private val repo: SolicitudEmpresaRepositoryPort = mockk()
+    private val fileStorage: FileStoragePort = mockk()
+    private val useCase = DescargarCartaSolicitudUseCase(repo, fileStorage)
+
+    private val pdfBytes = "contenido-pdf".toByteArray()
+
+    private val solicitud = SolicitudEmpresa(
+        id = 1L,
+        numeroSolicitud = "SOL-20260423-000001",
+        nombreEmpresa = "Empresa Test",
+        nitEmpresa = "900111222-1",
+        nombreContacto = "Juan",
+        cargoContacto = "Gerente",
+        correoContacto = "juan@test.com",
+        tipoDocumentoEstudiante = TipoDocumento.CC,
+        documentoEstudiante = "10350001",
+        nombreEstudiante = "Ana Gomez",
+        tipoValidacion = ValidationType.DEGREE,
+        aceptaTerminos = true,
+        rutaCarta = "solicitudes-empresa/2026/04/uuid.pdf",
+        estado = EstadoSolicitud.PENDIENTE
+    )
+
+    @Test
+    fun `descarga exitosa retorna los bytes del archivo`() {
+        every { repo.findByNumeroSolicitud("SOL-20260423-000001") } returns solicitud
+        every { fileStorage.loadAsBytes("solicitudes-empresa/2026/04/uuid.pdf") } returns pdfBytes
+
+        val result = useCase.execute("SOL-20260423-000001")
+
+        assertArrayEquals(pdfBytes, result)
+    }
+
+    @Test
+    fun `solicitud no encontrada lanza NoSuchElementException`() {
+        every { repo.findByNumeroSolicitud(any()) } returns null
+
+        val ex = assertThrows<NoSuchElementException> {
+            useCase.execute("SOL-19990101-000001")
+        }
+        assertTrue(ex.message!!.contains("SOL-19990101-000001"))
+    }
+
+    @Test
+    fun `archivo no encontrado en disco lanza IllegalArgumentException con mensaje claro`() {
+        every { repo.findByNumeroSolicitud("SOL-20260423-000001") } returns solicitud
+        every { fileStorage.loadAsBytes(any()) } throws NoSuchFileException("solicitudes-empresa/2026/04/uuid.pdf")
+
+        val ex = assertThrows<IllegalArgumentException> {
+            useCase.execute("SOL-20260423-000001")
+        }
+        assertTrue(ex.message!!.contains("SOL-20260423-000001"))
+        assertTrue(ex.message!!.contains("no está disponible"))
+        assertTrue(ex.message!!.contains("Contacta al administrador"))
+    }
+}

--- a/src/test/kotlin/co/edu/udemedellin/validacionacademica/usecase/ListarSolicitudesEmpresaUseCaseTest.kt
+++ b/src/test/kotlin/co/edu/udemedellin/validacionacademica/usecase/ListarSolicitudesEmpresaUseCaseTest.kt
@@ -1,0 +1,90 @@
+package co.edu.udemedellin.validacionacademica.usecase
+
+import co.edu.udemedellin.validacionacademica.application.usecase.ListarSolicitudesEmpresaUseCase
+import co.edu.udemedellin.validacionacademica.domain.model.*
+import co.edu.udemedellin.validacionacademica.domain.ports.SolicitudEmpresaRepositoryPort
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Sort
+
+class ListarSolicitudesEmpresaUseCaseTest {
+
+    private val repo: SolicitudEmpresaRepositoryPort = mockk()
+    private val useCase = ListarSolicitudesEmpresaUseCase(repo)
+
+    private fun solicitud(numero: String, estado: EstadoSolicitud) = SolicitudEmpresa(
+        id = 1L,
+        numeroSolicitud = numero,
+        nombreEmpresa = "Empresa Test",
+        nitEmpresa = "900111222-1",
+        nombreContacto = "Juan",
+        cargoContacto = "Gerente",
+        correoContacto = "juan@test.com",
+        tipoDocumentoEstudiante = TipoDocumento.CC,
+        documentoEstudiante = "10350001",
+        nombreEstudiante = "Ana Gomez",
+        tipoValidacion = ValidationType.DEGREE,
+        aceptaTerminos = true,
+        rutaCarta = "uploads/carta.pdf",
+        estado = estado
+    )
+
+    @Test
+    fun `sin filtro devuelve todas las solicitudes`() {
+        val contenido = listOf(
+            solicitud("SOL-20260423-000001", EstadoSolicitud.PENDIENTE),
+            solicitud("SOL-20260423-000002", EstadoSolicitud.APROBADA)
+        )
+        val pageableSlot = slot<Pageable>()
+        every { repo.findAll(capture(pageableSlot), null) } returns PageImpl(contenido)
+
+        val result = useCase.execute(page = 0, size = 20, estado = null)
+
+        assertEquals(2, result.totalElements)
+        assertNull(pageableSlot.captured.sort.getOrderFor("createdAt")?.let { null }
+            .also {
+                // Verificar orden createdAt DESC
+                val order = pageableSlot.captured.sort.getOrderFor("createdAt")
+                assertNotNull(order)
+                assertEquals(Sort.Direction.DESC, order!!.direction)
+            }
+        )
+    }
+
+    @Test
+    fun `con filtro de estado pasa el estado al repositorio`() {
+        val contenido = listOf(solicitud("SOL-20260423-000001", EstadoSolicitud.PENDIENTE))
+        every { repo.findAll(any(), EstadoSolicitud.PENDIENTE) } returns PageImpl(contenido)
+
+        val result = useCase.execute(page = 0, size = 20, estado = EstadoSolicitud.PENDIENTE)
+
+        assertEquals(1, result.totalElements)
+        assertEquals(EstadoSolicitud.PENDIENTE, result.content.first().estado)
+    }
+
+    @Test
+    fun `paginacion se pasa correctamente al repositorio`() {
+        val pageableSlot = slot<Pageable>()
+        every { repo.findAll(capture(pageableSlot), null) } returns PageImpl(emptyList())
+
+        useCase.execute(page = 2, size = 15, estado = null)
+
+        assertEquals(2, pageableSlot.captured.pageNumber)
+        assertEquals(15, pageableSlot.captured.pageSize)
+    }
+
+    @Test
+    fun `pagina vacia devuelve Page vacio sin errores`() {
+        every { repo.findAll(any(), any()) } returns PageImpl(emptyList())
+
+        val result = useCase.execute(page = 0, size = 20, estado = null)
+
+        assertTrue(result.isEmpty)
+        assertEquals(0, result.totalElements)
+    }
+}


### PR DESCRIPTION
## Contexto

Cierra el ciclo operativo del flujo de solicitudes empresa agregando un panel de gestión administrativo completo. El admin ahora puede:

- Ver todas las solicitudes paginadas y filtrar por estado.
- Abrir el detalle de cada solicitud.
- Descargar la carta de autorización adjunta (PDF).
- Ejecutar las 3 transiciones (marcar en revisión, aprobar, rechazar) desde la UI.
- Ver feedback visual de cada acción.

Antes de este PR, las transiciones solo podían ejecutarse vía Swagger o curl. Ahora hay una interfaz profesional.

## Dos commits lógicos

### Commit 1 — Backend (Paso A)

`feat(backend): endpoints admin de listado paginado y descarga de carta`

Dos endpoints nuevos en `AdminSolicitudEmpresaController`:

- `GET /api/v1/admin/solicitudes-empresa?page=0&size=20&estado=...` — listado paginado con filtro opcional por estado (PENDIENTE/EN_REVISION/APROBADA/RECHAZADA). Ordenamiento por `createdAt DESC`. Validación de `page >= 0`, `size` entre 1 y 100, `estado` debe ser valor válido del enum.
- `GET /api/v1/admin/solicitudes-empresa/{numero}/carta` — descarga el PDF adjunto con `Content-Type: application/pdf` y `Content-Disposition: attachment; filename="Carta_{numero}.pdf"`.

Use cases nuevos:
- `ListarSolicitudesEmpresaUseCase`
- `DescargarCartaSolicitudUseCase` (reusa `FileStoragePort.loadAsBytes()` que ya existía).

Repository port ampliado con `findAll(pageable, estado?)`.

Tests nuevos: 4 unitarios + 7 de integración (incluyendo verificación explícita de `Content-Disposition`).

### Commit 2 — Frontend (Paso B)

`feat(frontend): panel admin de solicitudes empresa con tabla paginada, modal de detalle y acciones`

Ruta nueva: `/admin/solicitudes` (accesible desde Navbar con link "Panel" cuando el admin está logeado).

Página nueva `AdminSolicitudes.jsx` + `.css`:
- Tabla paginada (20 por página) con badges de estado colorizados (verde=APROBADA, naranja=EN_REVISION, dorado=PENDIENTE, rojo=RECHAZADA).
- Filtro dropdown por estado.
- Modal de detalle con todos los campos + botón de descarga de PDF.
- Botones de acción contextuales según el estado actual (no se muestran en estados finales).
- Sub-formulario con textarea obligatorio al rechazar, con validación client-side.
- Toast de feedback (éxito/error) con auto-dismiss.
- Manejo de ESC y click-fuera para cerrar modal.
- Responsive (grid 2 columnas en desktop, 1 en mobile).

`api.js` ampliado con 5 funciones nuevas.

`Login.jsx` redirige a `/admin/solicitudes` tras login exitoso.

`Navbar.jsx` muestra link "Panel" cuando el admin está logeado (antes del botón "Salir").

Tests nuevos con vitest + testing-library: 2 tests de `AdminSolicitudes` (redirect sin token, estado vacío). Durante el trabajo se detectaron y arreglaron 6 tests rotos preexistentes en `Historial.test.jsx` (deuda técnica oculta del proyecto, fuera del scope original pero se corrigió para mantener la suite verde).

## Validación

- [x] Backend: `./gradlew test --rerun-tasks` → BUILD SUCCESSFUL en 56s, 29 test classes, 0 failures.
- [x] Frontend: `npm run test:run` → 23/23 tests pasan.
- [x] Frontend: `npm run build` → compila sin errores (312 KB bundle, 98 KB gzipped).
- [x] **Validación E2E con stack completo corriendo** (Postgres + backend Docker + Vite dev):
  - Login admin desde la UI → redirect correcto al panel.
  - Listado paginado muestra todas las solicitudes con filtro por estado.
  - Modal de detalle abre con todos los campos correctos.
  - Descarga del PDF adjunto funciona (Content-Disposition correcto, el navegador descarga en lugar de abrir en pestaña).
  - Transición "Marcar en revisión" → fila cambia a badge naranja + correo llega al contacto.
  - Transición "Aprobar" → fila cambia a badge verde + **correo llega al contacto con certificado PDF adjunto**.
  - Transición "Rechazar" con motivo → fila cambia a badge rojo + correo llega al contacto con el motivo escrito.
  - Intento de transición desde estado final → backend responde 409 y UI muestra toast de error.
- [x] Auditoría: cada transición queda registrada en `audit_events` con `performed_by = admin`, `target_document = numeroSolicitud`, `details` con JSON del cambio.

## Cambios fuera del scope original (señalados para transparencia)

- `frontend/vite.config.js`: agregado `esbuild: { jsx: 'automatic' }`. **Nota:** Vite 8 usa oxc y emite warning diciendo que ignora esta config. Queda como deuda menor para limpiar: la config es necesaria para Vitest pero no para el build de producción.
- `frontend/src/test/setup.js`: agregado `afterEach(cleanup)` explícito. Defensivo.
- `frontend/src/test/Historial.test.jsx`: 6 tests que estaban rotos en `main` fueron arreglados (async `act()`, `mockReset()`). Deuda técnica preexistente que se resolvió de paso.

## Pendientes fuera de este PR

- Issues #8 y #9 s